### PR TITLE
chore(docs): update CLAUDE.md to remove stale workflow references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ npm run preview            # Preview production build locally
 This is a **TDD-developed, serverless application** with three main components:
 
 ### 1. Frontend (`src/`)
+
 - **Framework**: React 18 + Vite + TypeScript
 - **Key Files**:
   - `src/App.tsx` - Main UI with search and request modal
@@ -39,6 +40,7 @@ This is a **TDD-developed, serverless application** with three main components:
   - `src/test/msw-server.ts` - Mock Service Worker setup for testing
 
 ### 2. Netlify Functions (`netlify/functions/`)
+
 Serverless edge functions that act as proxies to hide API keys and enable CORS:
 
 - **`search.ts`** - Proxies iTunes Search API requests
@@ -55,6 +57,7 @@ Serverless edge functions that act as proxies to hide API keys and enable CORS:
   - Submits POST to Google Form with `application/x-www-form-urlencoded`
 
 ### 3. Apps Script (`apps-script/`)
+
 Google Apps Script that runs on form submission to update the DJ's Google Doc queue:
 
 - **`index.ts`** - Entry point with `onFormSubmit()` trigger
@@ -63,6 +66,7 @@ Google Apps Script that runs on form submission to update the DJ's Google Doc qu
 - **`format.ts`** - Pure formatting logic for Doc entries (fully unit-tested)
 
 ### Shared Code (`shared/`)
+
 - **`formFields.ts`** - Google Form entry IDs mapping
   - **IMPORTANT**: Update these IDs with values from your prefilled Form URL
   - Extract `entry.xxxxx` parameters from the Google Form prefill link
@@ -108,6 +112,7 @@ The app uses Google Form as a submission endpoint to avoid managing a database:
 This project was built following **TDD (Test-Driven Development)**:
 
 ### Unit Tests (Vitest)
+
 - **Netlify Functions**: `netlify/functions/__tests__/*.test.ts`
   - Test request/response handling, error cases, URL transformations
 - **React Hooks**: `src/__tests__/*.test.tsx`
@@ -116,11 +121,13 @@ This project was built following **TDD (Test-Driven Development)**:
   - Test Doc formatting logic in isolation
 
 ### E2E Tests (Playwright)
+
 - **Smoke Test**: `tests/e2e/request.spec.ts`
   - Full user journey: search → select → request modal
   - Runs against live dev server (Vite auto-started by Playwright config)
 
 ### Test Coverage
+
 - Coverage configured in `vite.config.ts`
 - Run `npm run test:unit` to generate coverage report in `coverage/`
 - Target: >80% coverage for all non-trivial code
@@ -128,12 +135,14 @@ This project was built following **TDD (Test-Driven Development)**:
 ## Development Workflow
 
 ### TDD Cycle (Red-Green-Refactor)
+
 1. **Red**: Write failing test first
 2. **Green**: Write minimal code to pass
 3. **Refactor**: Clean up while keeping tests green
 4. Commit with conventional format: `feat:`, `fix:`, `test:`, `refactor:`
 
 ### Running Single Tests
+
 ```bash
 # Run specific test file
 npx vitest run src/__tests__/SearchView.test.tsx
@@ -146,6 +155,7 @@ npx vitest watch netlify/functions/__tests__/request.test.ts
 ```
 
 ### Debugging Netlify Functions Locally
+
 ```bash
 # Install Netlify CLI globally if needed
 npm install -g netlify-cli
@@ -158,7 +168,8 @@ netlify dev
 
 ## GitHub Actions - Claude Code Review
 
-The repository includes a Claude Code Review workflow (`.github/workflows/claude-code-review.yml`), but automatic PR reviews are **disabled** to reduce noise.
+Automatic PR reviews are **opt-in** via `@claude` mentions (configured via the GitHub App).
+There is no workflow file for automatic reviews.
 
 ### Requesting a Claude Review
 
@@ -172,20 +183,6 @@ To request a code review from Claude on any PR:
    - Security concerns
    - Test coverage
 
-### Why Automatic Reviews Are Disabled
-
-- **Reduces noise**: No reviews on every PR update
-- **Intentional reviews**: Reviews only when explicitly requested
-- **Cost efficiency**: Fewer GitHub Actions minutes and API calls
-- **Better workflow**: The workflow file remains for reference and manual triggering if needed
-
-### Workflow Configuration
-
-The workflow uses the `anthropics/claude-code-action@v1` GitHub Action with:
-- Restricted bash tools for GitHub CLI operations (`gh pr comment`, `gh pr diff`, etc.)
-- Project-specific guidance from `CLAUDE.md`
-- OAuth authentication via `CLAUDE_CODE_OAUTH_TOKEN` secret
-
 ## Code Style & Patterns
 
 - **TypeScript strict mode** enabled across all `tsconfig.*.json` files
@@ -198,16 +195,19 @@ The workflow uses the `anthropics/claude-code-action@v1` GitHub Action with:
 ## Known Issues & Gotchas
 
 ### iTunes Search API
+
 - **Rate Limit**: ~20 requests/minute per IP (enforced with 429 status)
 - **Preview URLs**: Some tracks lack `previewUrl` - handle null gracefully
 - **Artwork**: Not all tracks have high-res artwork - fallback to placeholder if needed
 
 ### Google Form Integration
+
 - **Entry IDs change** if you recreate the form - always get fresh IDs from prefill URL
 - **Form field order matters** - Apps Script expects field labels to match exactly
 - **URL format**: Must end in `/viewform` or `/prefill` for the request function to work
 
 ### Apps Script Deployment
+
 - **Trigger not automatic** - Must manually add "On form submit" trigger after deployment
 - **Doc ID is hardcoded** - Update `GOOGLE_DOC_ID` constant before deploying
 - **No local testing** - Use Vitest to test `format.ts` logic separately; Apps Script runtime can only be tested by submitting forms
@@ -215,14 +215,17 @@ The workflow uses the `anthropics/claude-code-action@v1` GitHub Action with:
 ## Environment Variables
 
 ### Required
+
 - `VITE_GOOGLE_FORM_URL` (local) or `GOOGLE_FORM_URL` (Netlify) - Prefilled Google Form base URL
 
 ### Optional
+
 - None currently; iTunes Search API requires no authentication
 
 ## Deployment
 
 ### Netlify (Recommended)
+
 1. Connect GitHub repository to Netlify
 2. Build command: `npm run build`
 3. Publish directory: `dist`
@@ -230,6 +233,7 @@ The workflow uses the `anthropics/claude-code-action@v1` GitHub Action with:
 5. Functions are auto-detected in `netlify/functions/`
 
 ### Verifying Deployment
+
 - Test search: `https://your-site.netlify.app/.netlify/functions/search?term=Beatles`
 - Expected: JSON array of tracks
 - Test form submission via frontend UI (check Google Doc for entry)
@@ -244,18 +248,21 @@ The workflow uses the `anthropics/claude-code-action@v1` GitHub Action with:
 ## Common Development Tasks
 
 ### Adding a New Netlify Function
+
 1. Create `netlify/functions/{name}.ts`
 2. Export `handler: Handler` from `@netlify/functions`
 3. Add tests in `netlify/functions/__tests__/{name}.test.ts`
 4. Access at `/.netlify/functions/{name}` in dev/production
 
 ### Updating Google Form Fields
+
 1. Edit Form, get new prefill URL
 2. Extract all `entry.xxxxx` IDs
 3. Update `shared/formFields.ts` mapping
 4. Restart dev server to pick up changes
 
 ### Debugging Apps Script
+
 - Apps Script has limited debugging - console.log goes to Executions log
 - Best practice: write logic in `format.ts` with Vitest tests, keep `index.ts` minimal
 - Test end-to-end by submitting a form and checking Google Doc output
@@ -263,20 +270,24 @@ The workflow uses the `anthropics/claude-code-action@v1` GitHub Action with:
 ## Dependencies Notes
 
 ### Core
+
 - **React 18** - UI framework
 - **Vite** - Build tool and dev server
 - **TypeScript** - Type safety across all code
 
 ### Testing
+
 - **Vitest** - Unit/integration test runner (Vite-native)
 - **Playwright** - E2E browser testing
 - **MSW** - Mock Service Worker for API mocking
 - **@testing-library/react** - React component testing utilities
 
 ### Netlify
+
 - **@netlify/functions** - Types for serverless function handlers
 
 ### Development
+
 - **ESLint** - Linting (flat config with TypeScript, React hooks, React Refresh plugins)
 - **Prettier** - Code formatting (configured via `prettier.config.cjs`)
 - **Husky** - Git hooks (`npm run prepare` installs hooks)

--- a/docs/plan/issues/025_chore_docs_update_claude_md_remove_stale_workflow_references.md
+++ b/docs/plan/issues/025_chore_docs_update_claude_md_remove_stale_workflow_references.md
@@ -1,0 +1,322 @@
+# GitHub Issue #25: chore(docs): update CLAUDE.md to remove stale claude-code-review workflow references
+
+**Issue:** [#25](https://github.com/denhamparry/djrequests/issues/25)
+**Status:** Reviewed (Approved)
+**Date:** 2026-02-28
+
+## Problem Statement
+
+`CLAUDE.md` contains a "GitHub Actions - Claude Code Review" section (lines ~159–188) that
+references the now-deleted `.github/workflows/claude-code-review.yml` file. This file was removed
+in issue #23 / PR #24. The documentation is now stale and misleading.
+
+Additionally, the issue notes pre-existing markdownlint violations throughout the file that should
+be fixed in the same cleanup PR.
+
+### Current Behavior
+
+- Section at lines 159–188 says: _"The repository includes a Claude Code Review workflow
+  (`.github/workflows/claude-code-review.yml`)..."_ — the file no longer exists.
+- Sub-sections "Why Automatic Reviews Are Disabled" and "Workflow Configuration" describe a
+  workflow file that has been deleted.
+- Various markdownlint violations exist throughout `CLAUDE.md` (unordered list style, missing blank
+  lines before lists, bare URLs, etc.).
+
+### Expected Behavior
+
+- The "GitHub Actions - Claude Code Review" section accurately reflects the current state: reviews
+  are opt-in via `@claude` GitHub App mentions; there is no workflow file.
+- All markdownlint rules pass on `CLAUDE.md` with no violations.
+
+## Current State Analysis
+
+### Relevant Files
+
+- `CLAUDE.md` — the only file requiring changes
+- `.github/workflows/` — only `ci.yml` remains; `claude-code-review.yml` was deleted in #23
+
+### Stale Section (lines 159–188)
+
+```markdown
+## GitHub Actions - Claude Code Review
+
+The repository includes a Claude Code Review workflow (`.github/workflows/claude-code-review.yml`),
+but automatic PR reviews are **disabled** to reduce noise.
+
+### Requesting a Claude Review
+...
+
+### Why Automatic Reviews Are Disabled
+...
+
+### Workflow Configuration
+The workflow uses the `anthropics/claude-code-action@v1` GitHub Action with:
+- Restricted bash tools for GitHub CLI operations (`gh pr comment`, `gh pr diff`, etc.)
+- Project-specific guidance from `CLAUDE.md`
+- OAuth authentication via `CLAUDE_CODE_OAUTH_TOKEN` secret
+```
+
+### Known Markdownlint Issues in Current File
+
+- Lists directly after headings with no blank line (MD032)
+- Unordered list items using mixed or bare hyphens inside ordered lists (MD004/MD007)
+- Ordered list items not starting at 1 or not incrementing (MD029)
+- Bare URLs not wrapped in angle brackets or markdown links (if any)
+
+### Related Context
+
+- Issue #23: deleted `.github/workflows/claude-code-review.yml`
+- Plan `docs/plan/issues/023_fix_ci_remove_broken_claude_code_review_workflow.md` — marked
+  `.github/workflows/claude-code-review.yml` as DELETED; CLAUDE.md update was listed as a
+  "Nice-to-Have" and not completed.
+
+## Solution Design
+
+### Approach
+
+Replace the stale "GitHub Actions - Claude Code Review" section with an accurate, concise
+description matching the current reality: Claude reviews are requested via `@claude` mention
+using the GitHub App (no workflow file). Then fix all pre-existing markdownlint violations
+detected by `markdownlint-cli2` (the pre-commit hook in `.pre-commit-config.yaml`).
+
+### Rationale
+
+- One-file change; no code, no tests, no dependencies impacted.
+- Fixing markdownlint issues ensures the pre-commit hook passes cleanly on this file in future
+  commits.
+
+### Trade-offs
+
+- Minimal approach: fix only `CLAUDE.md`, touch nothing else.
+- No structural reorganisation of CLAUDE.md beyond what is required.
+
+## Implementation Plan
+
+### Step 1: Replace the stale "GitHub Actions - Claude Code Review" section
+
+**File:** `CLAUDE.md`
+
+**Current content (lines ~159–188):**
+
+```markdown
+## GitHub Actions - Claude Code Review
+
+The repository includes a Claude Code Review workflow
+(`.github/workflows/claude-code-review.yml`), but automatic PR reviews are **disabled**
+to reduce noise.
+
+### Requesting a Claude Review
+
+To request a code review from Claude on any PR:
+
+1. Add a comment to the PR with `@claude`
+2. Claude will analyze the changes and provide feedback on:
+   - Code quality and best practices
+   - Potential bugs or issues
+   - Performance considerations
+   - Security concerns
+   - Test coverage
+
+### Why Automatic Reviews Are Disabled
+
+- **Reduces noise**: No reviews on every PR update
+- **Intentional reviews**: Reviews only when explicitly requested
+- **Cost efficiency**: Fewer GitHub Actions minutes and API calls
+- **Better workflow**: The workflow file remains for reference and manual triggering if needed
+
+### Workflow Configuration
+
+The workflow uses the `anthropics/claude-code-action@v1` GitHub Action with:
+- Restricted bash tools for GitHub CLI operations (`gh pr comment`, `gh pr diff`, etc.)
+- Project-specific guidance from `CLAUDE.md`
+- OAuth authentication via `CLAUDE_CODE_OAUTH_TOKEN` secret
+```
+
+**Replace with:**
+
+```markdown
+## GitHub Actions - Claude Code Review
+
+Automatic PR reviews are **opt-in** via `@claude` mentions (configured via the GitHub App).
+There is no workflow file for automatic reviews.
+
+### Requesting a Claude Review
+
+To request a code review from Claude on any PR:
+
+1. Add a comment to the PR with `@claude`
+2. Claude will analyze the changes and provide feedback on:
+   - Code quality and best practices
+   - Potential bugs or issues
+   - Performance considerations
+   - Security concerns
+   - Test coverage
+```
+
+### Step 2: Fix pre-existing markdownlint violations in CLAUDE.md
+
+Run markdownlint against the file to identify all violations:
+
+```bash
+pre-commit run markdownlint-cli2 --all-files
+```
+
+Common violations to fix:
+
+- Add blank lines before unordered lists that follow a heading or paragraph (MD032)
+- Ensure ordered list items increment correctly (MD029)
+- Add language specifiers to fenced code blocks where missing (MD040)
+- Fix any other violations reported by markdownlint-cli2
+
+### Step 3: Verify pre-commit hooks pass
+
+```bash
+pre-commit run --all-files
+```
+
+All hooks must pass with no failures before committing.
+
+## Testing Strategy
+
+### Verification
+
+1. **Pre-commit hooks pass**: `pre-commit run --all-files` reports no failures
+2. **Content accuracy**: Confirm no remaining references to `claude-code-review.yml`
+3. **Markdownlint clean**: `markdownlint-cli2` reports zero violations on `CLAUDE.md`
+
+### Regression
+
+- No application code changed; no unit or E2E tests required.
+- Confirm `ci.yml` is unmodified (`git diff HEAD -- .github/workflows/ci.yml` is empty).
+
+## Success Criteria
+
+- [ ] Stale "GitHub Actions - Claude Code Review" section replaced with accurate content
+- [ ] No references to `claude-code-review.yml` remain in `CLAUDE.md`
+- [ ] No references to `anthropics/claude-code-action@v1` or `CLAUDE_CODE_OAUTH_TOKEN` remain
+- [ ] `markdownlint-cli2` reports zero violations on `CLAUDE.md`
+- [ ] `pre-commit run --all-files` passes cleanly
+- [ ] GitHub issue #25 can be closed
+
+## Files Modified
+
+1. `CLAUDE.md` — replace stale workflow section; fix markdownlint violations
+
+## Related Issues and Tasks
+
+### Depends On
+
+- #23 (already merged) — deleted `.github/workflows/claude-code-review.yml`
+
+### Related
+
+- `docs/plan/issues/023_fix_ci_remove_broken_claude_code_review_workflow.md` — original fix plan
+  (CLAUDE.md update was listed as nice-to-have, not completed)
+
+## References
+
+- [GitHub Issue #25](https://github.com/denhamparry/djrequests/issues/25)
+- [Issue #23](https://github.com/denhamparry/djrequests/issues/23) — removed the workflow file
+- [markdownlint-cli2 rules](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md)
+
+## Notes
+
+### Key Insights
+
+- The `.github/workflows/` directory now only contains `ci.yml`; any mention of
+  `claude-code-review.yml` in docs is incorrect.
+- The GitHub App (`@claude` mentions) is the sole mechanism for Claude reviews — no workflow file
+  is involved.
+
+### Alternative Approaches Considered
+
+1. **Delete the entire section** — Rejected; the "Requesting a Claude Review" guidance is still
+   useful and accurate. ❌
+2. **Replace + fix markdownlint** — Chosen; minimal, targeted, and ensures pre-commit passes. ✅
+
+---
+
+## Plan Review
+
+**Reviewer:** Claude Code (workflow-research-plan)
+**Review Date:** 2026-02-28
+**Original Plan Date:** 2026-02-28
+
+### Review Summary
+
+- **Overall Assessment:** Approved
+- **Confidence Level:** High
+- **Recommendation:** Proceed to implementation
+
+### Strengths
+
+- Correctly identifies all three stale references in `CLAUDE.md` (lines 161, 184, 187) via
+  independent grep verification.
+- Confirmed `claude-code-review.yml` no longer exists in `.github/workflows/`; only `ci.yml`
+  remains.
+- Minimal scope: single-file documentation change, no code or test impact.
+- Proposed replacement text is accurate and concise.
+- Success criteria are measurable and complete.
+
+### Gaps Identified
+
+1. **Markdownlint violation count underestimated**
+   - **Impact:** Low (doesn't change the approach, only the scale of effort)
+   - **Detail:** The plan mentions "various markdownlint violations" with a short list of guessed
+     rule types. Independent research (`npx markdownlint-cli2 CLAUDE.md`) found **47 errors**,
+     primarily MD022 (blanks around headings) and MD032 (blanks around lists), spanning the
+     entire file. MD004/MD007/MD029 are not the primary issues.
+   - **Recommendation:** During implementation, run `npx markdownlint-cli2 CLAUDE.md` first to
+     get the exact list, then fix all 47 errors. The plan's Step 2 already says to run the tool
+     — just be aware the scope is larger than expected.
+
+### Edge Cases Not Covered
+
+1. **Plan document itself may have markdownlint violations**
+   - **Current Plan:** Does not mention linting the plan file.
+   - **Recommendation:** Run `pre-commit run --all-files` after editing; the pre-commit hook covers
+     all markdown files including docs/plan/. Fix any violations in this plan document too.
+
+### Alternative Approaches Evaluated
+
+1. **Delete the entire "GitHub Actions - Claude Code Review" section**
+   - **Pros:** Smallest diff; removes all stale content.
+   - **Cons:** Loses useful guidance on how to invoke `@claude` reviews.
+   - **Verdict:** Plan's choice to keep the "Requesting a Claude Review" subsection is correct. ✅
+
+2. **Only fix the stale section, skip markdownlint**
+   - **Pros:** Minimal change.
+   - **Cons:** Pre-commit hook would still fail on `CLAUDE.md` in future commits; defeats the
+     purpose of having linting enabled.
+   - **Verdict:** Plan's choice to fix markdownlint violations is correct. ✅
+
+### Risks and Concerns
+
+1. **Scale of markdownlint fixes**
+   - **Likelihood:** Certain (47 violations confirmed)
+   - **Impact:** Low — all fixes are whitespace/blank-line additions, not content changes
+   - **Mitigation:** Use `markdownlint-cli2 --fix CLAUDE.md` if auto-fix is supported; otherwise
+     fix manually guided by the tool output.
+
+### Required Changes
+
+No required changes to the plan. The solution approach is correct.
+
+### Optional Improvements
+
+- [ ] Note in Implementation Step 2 that there are exactly 47 violations (MD022, MD032 dominant)
+      so the implementer has accurate expectations.
+- [ ] Consider using `markdownlint-cli2 --fix` for auto-fixable rules to speed up implementation.
+
+### Verification Checklist
+
+- [x] Solution addresses root cause identified in GitHub issue
+- [x] All acceptance criteria from issue are covered
+- [x] Implementation steps are specific and actionable
+- [x] File paths and code references are accurate (verified: stale refs at lines 161, 184, 187)
+- [x] Security implications considered (none — docs only)
+- [x] Performance impact assessed (none — docs only)
+- [x] Test strategy covers critical paths (pre-commit hook run is sufficient)
+- [x] Documentation updates planned (this IS the documentation update)
+- [x] Related issues/dependencies identified (#23, plan 023)
+- [x] Breaking changes documented (none)

--- a/docs/plan/issues/025_chore_docs_update_claude_md_remove_stale_workflow_references.md
+++ b/docs/plan/issues/025_chore_docs_update_claude_md_remove_stale_workflow_references.md
@@ -1,7 +1,7 @@
 # GitHub Issue #25: chore(docs): update CLAUDE.md to remove stale claude-code-review workflow references
 
 **Issue:** [#25](https://github.com/denhamparry/djrequests/issues/25)
-**Status:** Reviewed (Approved)
+**Status:** Complete
 **Date:** 2026-02-28
 
 ## Problem Statement


### PR DESCRIPTION
## Summary

Removes stale references to the deleted `.github/workflows/claude-code-review.yml` file from
`CLAUDE.md` and fixes 47 pre-existing markdownlint violations, ensuring the pre-commit hook
passes cleanly on this file going forward.

## Changes Made

- Replace the "GitHub Actions - Claude Code Review" section body: remove text referencing
  `claude-code-review.yml`, `anthropics/claude-code-action@v1`, and `CLAUDE_CODE_OAUTH_TOKEN`
- Remove the "Why Automatic Reviews Are Disabled" and "Workflow Configuration" subsections
  (no longer applicable — the workflow file no longer exists)
- Add accurate replacement text: Claude reviews are opt-in via `@claude` GitHub App mentions;
  there is no workflow file
- Fix 47 pre-existing markdownlint violations throughout `CLAUDE.md` (MD022/MD032 — missing
  blank lines after headings and before/after lists)
- Add implementation plan document with research review

## Motivation

The `.github/workflows/claude-code-review.yml` file was deleted in #23. The corresponding
documentation in `CLAUDE.md` was listed as a nice-to-have cleanup at the time and tracked
as issue #25. This PR completes that cleanup.

The markdownlint violations meant the pre-commit hook would fail on `CLAUDE.md` in any future
commit that modified it, so fixing them now prevents future friction.

## Testing

- [x] `npx markdownlint-cli2 CLAUDE.md` reports 0 errors (was 47)
- [x] No remaining references to `claude-code-review.yml`, `CLAUDE_CODE_OAUTH_TOKEN`, or
  `anthropics/claude-code-action@v1` in `CLAUDE.md`
- [x] `pre-commit run` passes on staged files (all hooks: Passed)
- [x] `ci.yml` is unmodified
- [x] No application code changed; no unit or E2E tests required

## Breaking Changes

None — documentation-only change.

## Related Issues

Closes #25
Related to #23 (deleted the workflow file this doc referenced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)