### PR TITLE
fix(functions): tighten CORS to configured origin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,7 +224,8 @@ To request a code review from Claude on any PR:
 
 ### Optional
 
-- None currently; iTunes Search API requires no authentication
+- `ALLOWED_ORIGIN` - Origin allowed to call the Netlify functions (e.g. `https://djrequests.netlify.app`). Used in the `Access-Control-Allow-Origin` header on both `search` and `request`. Falls back to Netlify's auto-provided `URL` env var, then to `*` when neither is set (keeps `netlify dev` and tests working).
+- iTunes Search API requires no authentication.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,12 @@ Web app that lets guests search for tracks, submit requests through a Google For
 ## 🚀 Deployment
 
 - Netlify recommended: connect repo, set build command `npm run build`, publish directory `dist`.
-- Add environment variables (`VITE_GOOGLE_FORM_URL`, future API keys) via Netlify dashboard.
+- Add environment variables via Netlify dashboard:
+  - `GOOGLE_FORM_URL` (or `VITE_GOOGLE_FORM_URL`) — prefilled Form URL.
+  - `ALLOWED_ORIGIN` — origin allowed to call the Netlify functions
+    (e.g. `https://djrequests.netlify.app`). If unset, the functions fall
+    back to Netlify's auto-provided `URL` env var, then to `*` as a last
+    resort (useful for local `netlify dev`).
 - Enable Netlify Functions for `netlify/functions/search.ts`.
 - Optional fallback: GitHub Pages (requires proxy alternative for secrets).
 

--- a/docs/plan/issues/031_tighten_cors_netlify_functions.md
+++ b/docs/plan/issues/031_tighten_cors_netlify_functions.md
@@ -1,0 +1,84 @@
+---
+name: Tighten CORS on Netlify functions
+description: Restrict CORS on search and request functions to deployed origin
+type: plan
+status: Reviewed (Approved)
+issue: 31
+---
+
+# Issue #31 — Tighten CORS on Netlify functions to deployed origin only
+
+## Problem
+
+Both `netlify/functions/search.ts:46` and `netlify/functions/request.ts:25`
+emit `access-control-allow-origin: *`. Any third-party site can proxy iTunes
+searches through our Netlify account or submit song requests to our Google
+Form from a browser.
+
+## Approach
+
+Resolve the allowed origin at request time from the environment:
+
+1. `ALLOWED_ORIGIN` env var — explicit config (preferred in production)
+2. `process.env.URL` — Netlify auto-sets this to the primary deploy URL
+3. `*` — final fallback so local `netlify dev` and tests keep working
+
+A small shared helper avoids duplicating the resolution logic across both
+functions. Put it in `netlify/functions/_cors.ts` (leading underscore keeps
+Netlify from exposing it as a route — Netlify only deploys handlers that
+export a `handler` function, so this is a defence-in-depth naming choice
+rather than a strict requirement).
+
+## Changes
+
+### `netlify/functions/_cors.ts` (new)
+
+Export:
+
+- `resolveAllowedOrigin()` → reads `ALLOWED_ORIGIN`, then `URL`, else `*`
+- `corsHeaders()` → returns the three `access-control-allow-*` headers with
+  origin from `resolveAllowedOrigin()`
+
+### `netlify/functions/search.ts`
+
+- Import `corsHeaders` and use it in `jsonResponse`
+- Add an `OPTIONS` branch to `handler` that returns 204 with
+  `corsHeaders() + allow-methods: GET, OPTIONS` + `allow-headers: Content-Type`
+
+### `netlify/functions/request.ts`
+
+- Replace the module-level `corsHeaders` constant with a call to `corsHeaders()`
+  inside `jsonResponse` and the `OPTIONS` branch
+
+### Tests
+
+- `netlify/functions/__tests__/search.test.ts` — add two tests:
+  - `OPTIONS` returns 204 with the configured `access-control-allow-origin`
+  - `GET` responses reflect `ALLOWED_ORIGIN` when set
+- `netlify/functions/__tests__/request.test.ts` — add one test:
+  - Responses reflect `ALLOWED_ORIGIN` when set (both on success and OPTIONS)
+
+Use `beforeEach` to stub `process.env.ALLOWED_ORIGIN` and clear it in
+`afterEach`.
+
+### Docs
+
+- `README.md` — add `ALLOWED_ORIGIN` to the env-var table/section
+- `CLAUDE.md` — add `ALLOWED_ORIGIN` under "Environment Variables"
+
+## Files Modified
+
+- `netlify/functions/_cors.ts` (new)
+- `netlify/functions/search.ts`
+- `netlify/functions/request.ts`
+- `netlify/functions/__tests__/search.test.ts`
+- `netlify/functions/__tests__/request.test.ts`
+- `README.md`
+- `CLAUDE.md`
+
+## Verification
+
+1. `npm run lint`
+2. `npm run test:unit` — all existing + new tests pass
+3. Manually: `ALLOWED_ORIGIN=https://foo.example npm run dev`, hit
+   `/.netlify/functions/search?term=test`, confirm header in response

--- a/netlify/functions/__tests__/request.test.ts
+++ b/netlify/functions/__tests__/request.test.ts
@@ -90,6 +90,31 @@ describe('request function', () => {
     expect(JSON.parse(response.body).message).toMatch(/submitted successfully/i);
   });
 
+  it('uses ALLOWED_ORIGIN for CORS header on responses and OPTIONS', async () => {
+    process.env.ALLOWED_ORIGIN = 'https://djrequests.example';
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 200 });
+
+    const postResponse = await handler(
+      {
+        httpMethod: 'POST',
+        body: JSON.stringify({ song: { id: '1', title: 't', artist: 'a' } })
+      } as any,
+      {} as any
+    );
+    expect(postResponse.headers?.['access-control-allow-origin']).toBe(
+      'https://djrequests.example'
+    );
+
+    const optionsResponse = await handler(
+      { httpMethod: 'OPTIONS' } as any,
+      {} as any
+    );
+    expect(optionsResponse.statusCode).toBe(204);
+    expect(optionsResponse.headers?.['access-control-allow-origin']).toBe(
+      'https://djrequests.example'
+    );
+  });
+
   it('returns error when Google Form submission fails', async () => {
     fetchMock.mockResolvedValueOnce({ ok: false, status: 500 });
 

--- a/netlify/functions/__tests__/search.test.ts
+++ b/netlify/functions/__tests__/search.test.ts
@@ -19,16 +19,66 @@ const failureResponse = (status: number) => ({
 
 describe('search function', () => {
   const fetchMock = vi.fn();
+  const originalEnv = process.env;
 
   beforeEach(() => {
     vi.stubGlobal('fetch', fetchMock);
     vi.useFakeTimers();
+    process.env = { ...originalEnv };
+    delete process.env.ALLOWED_ORIGIN;
+    delete process.env.URL;
   });
 
   afterEach(() => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
     fetchMock.mockReset();
+    process.env = originalEnv;
+  });
+
+  it('uses ALLOWED_ORIGIN for CORS header on GET responses', async () => {
+    process.env.ALLOWED_ORIGIN = 'https://djrequests.example';
+    fetchMock.mockResolvedValueOnce(okResponse([]));
+
+    const promise = handler(
+      { queryStringParameters: { term: 'x' } } as any,
+      {} as any
+    );
+    await vi.runAllTimersAsync();
+    const response = await promise;
+
+    expect(response.headers?.['access-control-allow-origin']).toBe(
+      'https://djrequests.example'
+    );
+  });
+
+  it('responds to OPTIONS preflight with 204 and configured origin', async () => {
+    process.env.ALLOWED_ORIGIN = 'https://djrequests.example';
+
+    const response = await handler({ httpMethod: 'OPTIONS' } as any, {} as any);
+
+    expect(response.statusCode).toBe(204);
+    expect(response.headers?.['access-control-allow-origin']).toBe(
+      'https://djrequests.example'
+    );
+    expect(response.headers?.['access-control-allow-methods']).toMatch(/OPTIONS/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to Netlify URL env var when ALLOWED_ORIGIN is unset', async () => {
+    process.env.URL = 'https://auto-deploy.example';
+    fetchMock.mockResolvedValueOnce(okResponse([]));
+
+    const promise = handler(
+      { queryStringParameters: { term: 'x' } } as any,
+      {} as any
+    );
+    await vi.runAllTimersAsync();
+    const response = await promise;
+
+    expect(response.headers?.['access-control-allow-origin']).toBe(
+      'https://auto-deploy.example'
+    );
   });
 
   it('returns 400 when term is missing', async () => {

--- a/netlify/functions/_cors.ts
+++ b/netlify/functions/_cors.ts
@@ -1,0 +1,8 @@
+export const resolveAllowedOrigin = (): string =>
+  process.env.ALLOWED_ORIGIN ?? process.env.URL ?? '*';
+
+export const corsHeaders = (): Record<string, string> => ({
+  'access-control-allow-origin': resolveAllowedOrigin(),
+  'access-control-allow-methods': 'GET,POST,OPTIONS',
+  'access-control-allow-headers': 'Content-Type'
+});

--- a/netlify/functions/request.ts
+++ b/netlify/functions/request.ts
@@ -1,5 +1,6 @@
 import type { Handler } from '@netlify/functions';
 import { FORM_FIELD_IDS } from '../../shared/formFields';
+import { corsHeaders } from './_cors';
 
 type SongPayload = {
   id: string;
@@ -21,17 +22,11 @@ type RequestBody = {
   requester?: RequesterPayload;
 };
 
-const corsHeaders = {
-  'access-control-allow-origin': '*',
-  'access-control-allow-methods': 'POST,OPTIONS',
-  'access-control-allow-headers': 'Content-Type'
-};
-
 const jsonResponse = (statusCode: number, payload: Record<string, unknown>) => ({
   statusCode,
   headers: {
     'content-type': 'application/json',
-    ...corsHeaders
+    ...corsHeaders()
   },
   body: JSON.stringify(payload)
 });
@@ -79,7 +74,7 @@ export const handler: Handler = async (event) => {
   if (event.httpMethod === 'OPTIONS') {
     return {
       statusCode: 204,
-      headers: corsHeaders,
+      headers: corsHeaders(),
       body: ''
     };
   }

--- a/netlify/functions/search.ts
+++ b/netlify/functions/search.ts
@@ -1,4 +1,5 @@
 import type { Handler } from '@netlify/functions';
+import { corsHeaders } from './_cors';
 
 type ITunesTrack = {
   trackId: number;
@@ -43,7 +44,7 @@ const jsonResponse = (statusCode: number, payload: SearchResponse) => ({
   headers: {
     'content-type': 'application/json',
     'cache-control': 'public, max-age=60',
-    'access-control-allow-origin': '*'
+    ...corsHeaders()
   },
   body: JSON.stringify(payload)
 });
@@ -95,6 +96,10 @@ async function fetchFromItunes(url: string): Promise<UpstreamOutcome> {
 }
 
 export const handler: Handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: corsHeaders(), body: '' };
+  }
+
   const term = event.queryStringParameters?.term?.trim();
 
   if (!term) {


### PR DESCRIPTION
## Summary

- Resolve `Access-Control-Allow-Origin` at request time from `ALLOWED_ORIGIN`, falling back to Netlify's auto-provided `URL`, then `*` (so `netlify dev` and tests keep working).
- Share the resolution via `netlify/functions/_cors.ts` and apply it to both `search` and `request`.
- Add an `OPTIONS` preflight branch to `search` (parity with `request`).
- Document `ALLOWED_ORIGIN` in `README.md` and `CLAUDE.md`.

## Test plan

- [x] `npm run lint`
- [x] `npm run test:unit` (26 passed — includes 4 new CORS tests)
- [ ] After deploy: curl `/.netlify/functions/search?term=test` and confirm header matches `ALLOWED_ORIGIN`

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)