### PR TITLE
fix(functions): validate request payload and rate-limit submissions

### DIFF
--- a/docs/plan/issues/32_harden_request_validate_and_rate_limit.md
+++ b/docs/plan/issues/32_harden_request_validate_and_rate_limit.md
@@ -1,7 +1,7 @@
 # GitHub Issue #32: Harden request.ts — validate payload shape and rate-limit submissions
 
 **Issue:** [#32](https://github.com/denhamparry/djrequests/issues/32)
-**Status:** Planning
+**Status:** Reviewed (Approved)
 **Date:** 2026-04-16
 
 ## Problem Statement
@@ -386,3 +386,162 @@ surface the UI gap as a follow-up enhancement issue during Phase 4.5.
    for a no-infra fix.
 3. **Require `requester.name` strictly in this PR** — deferred: UI doesn't
    collect it yet; would break current submissions.
+
+## Plan Review
+
+**Reviewer:** Claude Code (workflow-research-plan)
+**Review Date:** 2026-04-16
+**Original Plan Date:** 2026-04-16
+
+### Review Summary
+
+- **Overall Assessment:** Approved
+- **Confidence Level:** High
+- **Recommendation:** Proceed to implementation (addressing the Required
+  Changes inline during Phase 3)
+
+### Strengths
+
+- Module naming (`_validate.ts`, `_rateLimit.ts`) matches the existing
+  `_cors.ts` convention — Netlify treats underscore-prefixed files as
+  utilities, not deployable functions.
+- Vitest `include` glob `netlify/functions/__tests__/**/*.test.ts` (verified in
+  `vite.config.ts`) will pick up the proposed test files without config
+  changes.
+- Validator returns a normalised `ValidatedRequest` so the handler can drop
+  the `?? ''` fallbacks — good reduction in branching.
+- Correctly identifies the in-memory limiter's weakness (not shared across
+  cold starts / instances) and proposes documenting it rather than papering
+  over it.
+- Sensible call order: cheap checks → rate limit → validation → form post.
+- Correct handling of the `requester.name` tension between the issue's
+  "required" wording and the current UI not collecting a name. Deferring the
+  strict requirement and raising a follow-up is the right call given this
+  PR's scope.
+
+### Gaps Identified
+
+1. **Gap 1: In-memory `hits` Map has no eviction.**
+   - **Impact:** Low
+   - **Recommendation:** Keep this gap explicit in the module's file-level
+     comment. Under the expected threat model (single bar event, tens of
+     guests) the entry count is trivial, but a one-line "entries are pruned
+     only when the same key is touched" note prevents future confusion.
+
+2. **Gap 2: Plan does not specify behaviour when `x-forwarded-for` is
+   missing.**
+   - **Impact:** Low
+   - **Recommendation:** The sketched `resolveClientKey` returns `'unknown'`
+     in that case, which would collapse all such requests onto one bucket —
+     acceptable. Add a test asserting missing-header requests share the
+     `'unknown'` bucket so the behaviour is pinned.
+
+### Edge Cases Not Covered
+
+1. **Empty-string optional fields vs. missing optional fields.**
+   - **Current Plan:** `optionalString` returns `null` for `undefined`,
+     `null`, or `''` — good. But the validator then passes `null` where the
+     current handler passed `''` into `appendField`. The handler uses
+     `appendField(params, id, value ?? '')`, so `null` still becomes `''` on
+     the wire. ✅ No change needed, but add a test asserting a submitted
+     form with `album: ''` produces an empty `entry.<album>` param (no
+     regression).
+
+2. **Test state leakage between the new rate-limit tests and existing
+   request tests.**
+   - **Current Plan:** Plan mentions calling `resetRateLimit()` in
+     `beforeEach`.
+   - **Recommendation:** Also call it in the new `_rateLimit.test.ts` file's
+     `beforeEach` to stop ordering-dependent flakes when running in parallel
+     with the handler suite.
+
+3. **Non-string `song`/`requester` (e.g. an array).**
+   - **Current Plan:** `typeof song !== 'object'` check — but arrays are
+     `object`. An array would slip through to property access and fail
+     silently on `song.id` (undefined → 400 via requireString). Functional,
+     but tighten by rejecting arrays explicitly or note the behaviour is
+     acceptable because the final error surface is still a 400.
+   - **Recommendation:** Non-blocking. Add an `Array.isArray(song)` guard
+     for defense-in-depth, or leave and rely on the downstream 400.
+
+### Alternative Approaches (Reviewer Perspective)
+
+1. **Netlify `@netlify/plugin-rate-limit` or Edge Functions.**
+   - **Pros:** Cross-instance state.
+   - **Cons:** New infrastructure; out of scope.
+   - **Verdict:** Plan's in-memory approach is correct for the stated
+     threat model.
+
+2. **Use `zod` for the validator.**
+   - **Pros:** Less custom parsing code; better error messages.
+   - **Cons:** Adds a dependency to a currently dep-free function; marginal
+     value for ~6 fields.
+   - **Verdict:** Plan's hand-rolled choice is correct here.
+
+### Risks and Concerns
+
+1. **Risk: Updating the `request.test.ts` happy-path payload to include
+   `requester.name` is not strictly required if the plan keeps
+   `requester.name` optional (Option 1).**
+   - **Likelihood:** Medium (plan says "Update happy-path payloads to include
+     `requester.name` (required)" but also recommends Option 1 elsewhere).
+   - **Impact:** Low — inconsistent wording only.
+   - **Mitigation:** Clarify in Phase 3 that `requester.name` is **not**
+     made required in this PR; tests can either add it or leave it absent.
+     See Required Change #1.
+
+2. **Risk: Existing "missing song payload" test asserts error message matches
+   `/song information/i`.**
+   - **Likelihood:** High (the new validator returns `'Song information is
+     required'` — that matches).
+   - **Impact:** None.
+   - **Mitigation:** Keep the validator error message literal stable.
+
+3. **Risk: Shared limiter state across tests could mask a bug where the
+   limiter state leaks between functions (e.g. if `search.ts` were ever
+   wired to the same limiter).**
+   - **Likelihood:** Low (plan scopes the limiter to `request.ts` only).
+   - **Impact:** Low.
+   - **Mitigation:** None needed; noted for awareness.
+
+### Required Changes
+
+**Changes that must be addressed during implementation (not a plan revision):**
+
+- [ ] Clarify that `requester.name` stays **optional** in this PR (falls
+      back to `'Anonymous'` or empty string when missing). Do not update
+      existing happy-path tests to add `requester.name`; instead add a
+      *new* test asserting a payload without a requester block still
+      succeeds, and another asserting a payload with `requester: { name: 'A' }`
+      succeeds. This resolves the self-conflicting wording between Step 3's
+      "Update happy-path payloads to include `requester.name` (required)"
+      and the Open Question's "Recommended: Option 1".
+- [ ] Add a test for the missing-`x-forwarded-for` path so the fallback
+      key is pinned.
+- [ ] Ensure `_rateLimit.test.ts` calls `resetRateLimit()` in `beforeEach`.
+
+### Optional Improvements
+
+- [ ] Add an `Array.isArray(song)` explicit reject for defence-in-depth.
+- [ ] Include a short module-level comment on `_rateLimit.ts` documenting
+      the lack of TTL eviction (size is bounded by unique IP count only).
+- [ ] Consider returning `{ error, field }` from the validator so the client
+      could surface which field failed; not required for this PR.
+
+### Verification Checklist
+
+- [x] Solution addresses root cause identified in GitHub issue
+- [x] All acceptance criteria from issue are covered (with the
+      `requester.name` strictness deferral called out)
+- [x] Implementation steps are specific and actionable
+- [x] File paths and code references are accurate (`_cors.ts` convention
+      confirmed; vitest include glob verified)
+- [x] Security implications considered and addressed (input validation,
+      length caps, rate limiting)
+- [x] Performance impact assessed (O(k) per request where k ≤ 5)
+- [x] Test strategy covers critical paths and edge cases
+- [x] Documentation updates planned (module comments)
+- [x] Related issues/dependencies identified (UI does not collect
+      `requester.name` — flagged as follow-up)
+- [x] Breaking changes documented (400s for malformed payloads — previously
+      accepted silently)

--- a/docs/plan/issues/32_harden_request_validate_and_rate_limit.md
+++ b/docs/plan/issues/32_harden_request_validate_and_rate_limit.md
@@ -1,0 +1,388 @@
+# GitHub Issue #32: Harden request.ts — validate payload shape and rate-limit submissions
+
+**Issue:** [#32](https://github.com/denhamparry/djrequests/issues/32)
+**Status:** Planning
+**Date:** 2026-04-16
+
+## Problem Statement
+
+`netlify/functions/request.ts` is the public write surface for the app but has
+two hardening gaps:
+
+### Current Behavior
+
+- **No payload shape validation.** Only `payload.song` truthiness is checked.
+  Missing `song.id`/`song.title`/`song.artist` or a missing
+  `requester.name` still results in a successful submission with empty Google
+  Form entries, which pollutes the Google Sheet and Doc queue.
+- **No submission throttling.** A guest holding the submit button (or a
+  malicious client bypassing the UI) can flood the Google Sheet / Doc. The
+  client disables the button only while `requestingSongId === song.id`
+  (`src/App.tsx:115`), which does not prevent rapid sequential requests for
+  different songs or direct API calls.
+
+### Expected Behavior
+
+- Garbage/partial payloads are rejected with `400` and a clear error.
+- Rapid submissions from the same IP are rejected with `429` and a
+  `Retry-After` header after a reasonable burst (issue suggests 5/minute).
+- Client-side submit button stays disabled for a short cooldown after a
+  successful/failed submission to avoid accidental double-taps.
+
+## Current State Analysis
+
+### Relevant Code
+
+- `netlify/functions/request.ts:73-153` — request handler. Only validates
+  method, body present, JSON parseable, and `payload.song` truthy.
+- `netlify/functions/__tests__/request.test.ts` — existing tests for method,
+  missing-song, happy path, CORS, Google Form failure.
+- `src/App.tsx:14-39` — `handleRequest`. Disables button only per-song while
+  in-flight.
+- `shared/formFields.ts` — form field IDs the function populates.
+- `netlify/functions/_cors.ts` — CORS helper.
+
+### Constraints
+
+- **No new runtime dependencies desired.** Package.json lists only React
+  runtime deps; adding `zod` here adds bundle weight to a serverless function
+  that currently ships zero deps. Hand-rolled guards are preferred.
+- **Netlify functions are stateless and per-region.** An in-memory Map works
+  for a single-region deployment but does not share state across cold starts
+  or instances. This is acceptable for the threat model (casual guest flood,
+  not a determined attacker) — but must be documented.
+- **Client IP source.** Netlify sets `x-forwarded-for` (comma-separated list;
+  left-most entry is the original client). `event.headers` keys are
+  lowercased.
+
+## Solution Design
+
+### Approach
+
+1. Add a hand-rolled validator for `{ song, requester }` that returns a
+   normalised payload on success or a descriptive 400 error on failure.
+2. Add an in-memory sliding-window rate limiter keyed by client IP. Default:
+   5 submissions / 60s window. Return `429` with `Retry-After` (seconds) when
+   exceeded.
+3. Extend the client `submitting` state to briefly cooldown the row button
+   after any submission (success or error) to prevent accidental doubles.
+
+### Rationale / Trade-offs
+
+- Hand-rolled validator keeps the function dependency-free and easy to audit.
+  The shape is small enough that zod would be overkill.
+- An in-memory limiter is imperfect (not shared across instances / cold
+  starts) but matches the issue's guidance and is a meaningful brake on
+  casual floods. We document the limitation in code and the plan.
+- The limiter runs **before** validation so that a flood of malformed
+  requests cannot exhaust Google Form quota via the validation path — but
+  after the method/body checks (cheap filters first for simple misuse).
+
+### Implementation
+
+#### New module: `netlify/functions/_validate.ts`
+
+```ts
+export type ValidatedSong = {
+  id: string;
+  title: string;
+  artist: string;
+  album: string | null;
+  artworkUrl: string | null;
+  previewUrl: string | null;
+};
+
+export type ValidatedRequester = {
+  name: string;
+  dedication: string | null;
+  contact: string | null;
+};
+
+export type ValidatedRequest = {
+  song: ValidatedSong;
+  requester: ValidatedRequester;
+};
+
+export type ValidationResult =
+  | { ok: true; value: ValidatedRequest }
+  | { ok: false; error: string };
+
+const MAX_STRING = 500;
+
+const requireString = (value: unknown, field: string): string | { error: string } => {
+  if (typeof value !== 'string') return { error: `${field} is required` };
+  const trimmed = value.trim();
+  if (!trimmed) return { error: `${field} is required` };
+  if (trimmed.length > MAX_STRING) return { error: `${field} is too long` };
+  return trimmed;
+};
+
+const optionalString = (value: unknown, field: string): string | null | { error: string } => {
+  if (value === undefined || value === null || value === '') return null;
+  if (typeof value !== 'string') return { error: `${field} must be a string` };
+  if (value.length > MAX_STRING) return { error: `${field} is too long` };
+  return value.trim() || null;
+};
+
+export const validateRequestBody = (raw: unknown): ValidationResult => {
+  if (!raw || typeof raw !== 'object') {
+    return { ok: false, error: 'Request body must be an object' };
+  }
+  const body = raw as Record<string, unknown>;
+  const song = body.song as Record<string, unknown> | undefined;
+  const requester = (body.requester ?? {}) as Record<string, unknown>;
+
+  if (!song || typeof song !== 'object') {
+    return { ok: false, error: 'Song information is required' };
+  }
+
+  const id = requireString(song.id, 'song.id');
+  if (typeof id === 'object') return { ok: false, error: id.error };
+  const title = requireString(song.title, 'song.title');
+  if (typeof title === 'object') return { ok: false, error: title.error };
+  const artist = requireString(song.artist, 'song.artist');
+  if (typeof artist === 'object') return { ok: false, error: artist.error };
+
+  const album = optionalString(song.album, 'song.album');
+  if (album && typeof album === 'object') return { ok: false, error: album.error };
+  const artworkUrl = optionalString(song.artworkUrl, 'song.artworkUrl');
+  if (artworkUrl && typeof artworkUrl === 'object') return { ok: false, error: artworkUrl.error };
+  const previewUrl = optionalString(song.previewUrl, 'song.previewUrl');
+  if (previewUrl && typeof previewUrl === 'object') return { ok: false, error: previewUrl.error };
+
+  const name = requireString(requester.name, 'requester.name');
+  if (typeof name === 'object') return { ok: false, error: name.error };
+  const dedication = optionalString(requester.dedication, 'requester.dedication');
+  if (dedication && typeof dedication === 'object') return { ok: false, error: dedication.error };
+  const contact = optionalString(requester.contact, 'requester.contact');
+  if (contact && typeof contact === 'object') return { ok: false, error: contact.error };
+
+  return {
+    ok: true,
+    value: {
+      song: {
+        id,
+        title,
+        artist,
+        album: album as string | null,
+        artworkUrl: artworkUrl as string | null,
+        previewUrl: previewUrl as string | null
+      },
+      requester: {
+        name,
+        dedication: dedication as string | null,
+        contact: contact as string | null
+      }
+    }
+  };
+};
+```
+
+#### New module: `netlify/functions/_rateLimit.ts`
+
+```ts
+// In-memory sliding-window rate limiter.
+// Limitation: per-instance state only — not shared across Netlify function
+// instances or cold starts. Adequate for casual flood protection only.
+const WINDOW_MS = 60_000;
+const MAX_REQUESTS = 5;
+
+const hits = new Map<string, number[]>();
+
+export type RateLimitResult =
+  | { allowed: true }
+  | { allowed: false; retryAfterSeconds: number };
+
+export const checkRateLimit = (
+  key: string,
+  now: number = Date.now()
+): RateLimitResult => {
+  const windowStart = now - WINDOW_MS;
+  const existing = (hits.get(key) ?? []).filter((t) => t > windowStart);
+
+  if (existing.length >= MAX_REQUESTS) {
+    const retryAfterMs = existing[0] + WINDOW_MS - now;
+    return { allowed: false, retryAfterSeconds: Math.max(1, Math.ceil(retryAfterMs / 1000)) };
+  }
+
+  existing.push(now);
+  hits.set(key, existing);
+  return { allowed: true };
+};
+
+export const resetRateLimit = () => hits.clear();
+
+export const resolveClientKey = (headers: Record<string, string | undefined>): string => {
+  const forwarded = headers['x-forwarded-for'] ?? headers['X-Forwarded-For'];
+  if (forwarded) {
+    const first = forwarded.split(',')[0]?.trim();
+    if (first) return first;
+  }
+  return headers['client-ip'] ?? 'unknown';
+};
+```
+
+#### Wire into `request.ts`
+
+- After method + body checks, compute `clientKey = resolveClientKey(event.headers)`.
+- Call `checkRateLimit(clientKey)` — if not allowed, return
+  `429` with `Retry-After` header and JSON error.
+- Replace the current `if (!payload.song)` block with `validateRequestBody`;
+  on failure return `400` with the validator's error.
+- Use the validator's normalised `value` to populate form fields.
+
+#### Client: `src/App.tsx`
+
+Add a short (e.g. 3s) cooldown after a submission completes. Implementation:
+keep `requestingSongId` set until a `setTimeout` clears it. Keep the existing
+success/error feedback.
+
+## Implementation Plan
+
+### Step 1: Add validator module + tests
+
+**Files:**
+
+- `netlify/functions/_validate.ts` (new)
+- `netlify/functions/__tests__/_validate.test.ts` (new)
+
+**Tests:**
+
+- missing `song` → error
+- missing `song.id` / `song.title` / `song.artist` → error each
+- missing `requester.name` → error
+- non-string types → error
+- over-length (>500 chars) → error
+- valid minimal payload (required only) → `ok: true` with nulls for optional
+- valid full payload → `ok: true` with all fields
+
+### Step 2: Add rate limiter module + tests
+
+**Files:**
+
+- `netlify/functions/_rateLimit.ts` (new)
+- `netlify/functions/__tests__/_rateLimit.test.ts` (new)
+
+**Tests:**
+
+- 5 requests allowed in same window
+- 6th request blocked, returns `retryAfterSeconds >= 1`
+- Request outside window resets count
+- `resolveClientKey` parses `x-forwarded-for`, takes left-most, falls back
+
+### Step 3: Wire into request handler + tests
+
+**Files:**
+
+- `netlify/functions/request.ts`
+- `netlify/functions/__tests__/request.test.ts`
+
+**Changes:**
+
+- Import validator + rate limiter.
+- Call `resetRateLimit()` in existing `beforeEach` test hook.
+- Add rate limit check and validation branch with appropriate status codes.
+
+**New/updated tests:**
+
+- Existing "missing song payload" test still asserts 400 via new validator error.
+- Add: missing `song.id` returns 400.
+- Add: missing `requester.name` returns 400.
+- Add: 6th rapid submission from same IP is rejected with 429 and
+  `Retry-After` header.
+- Update happy-path payloads to include `requester.name` (required).
+
+### Step 4: Client cooldown
+
+**Files:**
+
+- `src/App.tsx`
+- `src/__tests__/App.test.tsx` (if exists; otherwise skip — no existing App
+  unit test)
+
+**Changes:**
+
+- After `submitSongRequest` resolves/rejects, keep button disabled for ~3s
+  via `setTimeout`.
+- Clear timer on unmount.
+
+## Testing Strategy
+
+### Unit Testing (Vitest)
+
+- New `_validate.test.ts` covers validator cases above.
+- New `_rateLimit.test.ts` covers limiter windowing and IP extraction.
+- `request.test.ts` extended for 400/429 paths.
+
+### Regression Testing
+
+- Existing happy path still passes with `requester.name` supplied.
+- CORS header tests still pass.
+- 502 on Google Form failure still passes.
+
+### Manual / E2E
+
+- Playwright smoke (`tests/e2e/request.spec.ts`) should still succeed
+  provided the UI supplies `requester.name` (or we keep requester optional
+  until UI collects it — see **Open Question** below).
+
+## Open Question (flag during research review)
+
+The current UI (`src/App.tsx`) **does not collect requester name** — it only
+sends `song`. If we make `requester.name` strictly required at the backend,
+the current UI submission will start failing with 400. Options:
+
+1. Keep `requester.name` **optional** (fall back to `'Anonymous'` when
+   missing) — matches current behaviour, issue wording "Required:
+   `requester.name`" may be aspirational.
+2. Update the UI to collect requester name before making it required.
+
+**Recommended:** Option 1 for this PR (validation + rate-limit scope only) —
+surface the UI gap as a follow-up enhancement issue during Phase 4.5.
+
+## Success Criteria
+
+- [ ] Validator module + tests added
+- [ ] Rate limiter module + tests added
+- [ ] `request.ts` returns 400 on invalid payload (missing required fields,
+      wrong types, over-length)
+- [ ] `request.ts` returns 429 with `Retry-After` after 5 requests/minute
+      from same IP
+- [ ] `src/App.tsx` has post-submit cooldown
+- [ ] All existing tests still pass
+- [ ] `npm run lint` passes
+- [ ] `npm run test:unit` coverage meets project bar
+
+## Files Modified
+
+1. `netlify/functions/_validate.ts` — new validator
+2. `netlify/functions/_rateLimit.ts` — new in-memory rate limiter
+3. `netlify/functions/request.ts` — wire validator + rate limiter
+4. `netlify/functions/__tests__/_validate.test.ts` — validator tests
+5. `netlify/functions/__tests__/_rateLimit.test.ts` — rate limiter tests
+6. `netlify/functions/__tests__/request.test.ts` — 400/429 path tests + adjust
+   existing payloads
+7. `src/App.tsx` — post-submit cooldown
+
+## References
+
+- [GitHub Issue #32](https://github.com/denhamparry/djrequests/issues/32)
+- `netlify/functions/request.ts` (current handler)
+- `CLAUDE.md` — Known Issues → Google Form Integration
+
+## Notes
+
+### Key Insights
+
+- Limiter state is instance-local; this is a speed bump, not a wall.
+  Documented in module comment.
+- Validator returns a normalised `ValidatedRequest` so the handler no longer
+  needs `?? ''` fallbacks when populating form fields.
+
+### Alternative Approaches Considered
+
+1. **Add `zod`** — rejected: new dep for a tiny shape.
+2. **Netlify Edge rate limiting (external provider)** — rejected: out of scope
+   for a no-infra fix.
+3. **Require `requester.name` strictly in this PR** — deferred: UI doesn't
+   collect it yet; would break current submissions.

--- a/netlify/functions/__tests__/_rateLimit.test.ts
+++ b/netlify/functions/__tests__/_rateLimit.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  checkRateLimit,
+  resetRateLimit,
+  resolveClientKey
+} from '../_rateLimit';
+
+describe('checkRateLimit', () => {
+  beforeEach(() => {
+    resetRateLimit();
+  });
+
+  it('allows up to 5 requests in the same window', () => {
+    const now = 1_000_000;
+    for (let i = 0; i < 5; i += 1) {
+      const result = checkRateLimit('ip-1', now + i);
+      expect(result.allowed).toBe(true);
+    }
+  });
+
+  it('blocks the 6th request and returns retryAfterSeconds >= 1', () => {
+    const now = 1_000_000;
+    for (let i = 0; i < 5; i += 1) {
+      checkRateLimit('ip-1', now + i);
+    }
+    const blocked = checkRateLimit('ip-1', now + 10);
+    expect(blocked.allowed).toBe(false);
+    if (!blocked.allowed) {
+      expect(blocked.retryAfterSeconds).toBeGreaterThanOrEqual(1);
+      expect(blocked.retryAfterSeconds).toBeLessThanOrEqual(60);
+    }
+  });
+
+  it('allows requests again after the window elapses', () => {
+    const now = 1_000_000;
+    for (let i = 0; i < 5; i += 1) {
+      checkRateLimit('ip-1', now + i);
+    }
+    const later = checkRateLimit('ip-1', now + 60_001);
+    expect(later.allowed).toBe(true);
+  });
+
+  it('tracks different keys independently', () => {
+    const now = 1_000_000;
+    for (let i = 0; i < 5; i += 1) {
+      checkRateLimit('ip-1', now + i);
+    }
+    const other = checkRateLimit('ip-2', now + 10);
+    expect(other.allowed).toBe(true);
+  });
+});
+
+describe('resolveClientKey', () => {
+  it('uses the left-most entry of x-forwarded-for', () => {
+    expect(
+      resolveClientKey({ 'x-forwarded-for': '1.2.3.4, 5.6.7.8' })
+    ).toBe('1.2.3.4');
+  });
+
+  it('trims whitespace', () => {
+    expect(resolveClientKey({ 'x-forwarded-for': '  1.2.3.4  ' })).toBe('1.2.3.4');
+  });
+
+  it('falls back to client-ip header', () => {
+    expect(resolveClientKey({ 'client-ip': '9.9.9.9' })).toBe('9.9.9.9');
+  });
+
+  it('returns "unknown" when no IP headers are present', () => {
+    expect(resolveClientKey({})).toBe('unknown');
+  });
+});

--- a/netlify/functions/__tests__/_rateLimit.test.ts
+++ b/netlify/functions/__tests__/_rateLimit.test.ts
@@ -69,4 +69,9 @@ describe('resolveClientKey', () => {
   it('returns "unknown" when no IP headers are present', () => {
     expect(resolveClientKey({})).toBe('unknown');
   });
+
+  it('lowercases header keys', () => {
+    expect(resolveClientKey({ 'X-Forwarded-For': '1.2.3.4' })).toBe('1.2.3.4');
+    expect(resolveClientKey({ 'Client-IP': '9.9.9.9' })).toBe('9.9.9.9');
+  });
 });

--- a/netlify/functions/__tests__/_validate.test.ts
+++ b/netlify/functions/__tests__/_validate.test.ts
@@ -1,0 +1,140 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { validateRequestBody } from '../_validate';
+
+describe('validateRequestBody', () => {
+  const baseSong = { id: '1', title: 'Song', artist: 'Artist' };
+
+  it('rejects non-object bodies', () => {
+    expect(validateRequestBody(null)).toEqual({
+      ok: false,
+      error: 'Request body must be an object'
+    });
+    expect(validateRequestBody('hello')).toEqual({
+      ok: false,
+      error: 'Request body must be an object'
+    });
+    expect(validateRequestBody([])).toEqual({
+      ok: false,
+      error: 'Request body must be an object'
+    });
+  });
+
+  it('rejects missing song', () => {
+    const result = validateRequestBody({});
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/song information/i);
+  });
+
+  it('rejects song as array', () => {
+    const result = validateRequestBody({ song: [] });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/song information/i);
+  });
+
+  it.each([
+    ['id', 'song.id'],
+    ['title', 'song.title'],
+    ['artist', 'song.artist']
+  ])('rejects missing song.%s', (field, expectedName) => {
+    const song = { ...baseSong } as Record<string, unknown>;
+    delete song[field];
+    const result = validateRequestBody({ song });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe(`${expectedName} is required`);
+  });
+
+  it('rejects non-string song.id', () => {
+    const result = validateRequestBody({ song: { ...baseSong, id: 123 } });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects over-length fields', () => {
+    const result = validateRequestBody({
+      song: { ...baseSong, title: 'x'.repeat(501) }
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/too long/);
+  });
+
+  it('accepts minimal valid payload without requester', () => {
+    const result = validateRequestBody({ song: baseSong });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.song).toEqual({
+        id: '1',
+        title: 'Song',
+        artist: 'Artist',
+        album: null,
+        artworkUrl: null,
+        previewUrl: null
+      });
+      expect(result.value.requester).toEqual({
+        name: null,
+        dedication: null,
+        contact: null
+      });
+    }
+  });
+
+  it('trims whitespace on required strings', () => {
+    const result = validateRequestBody({
+      song: { id: '  1  ', title: ' Song ', artist: ' Artist ' }
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.song.id).toBe('1');
+      expect(result.value.song.title).toBe('Song');
+    }
+  });
+
+  it('rejects whitespace-only required strings', () => {
+    const result = validateRequestBody({
+      song: { ...baseSong, title: '   ' }
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe('song.title is required');
+  });
+
+  it('accepts full payload with optional fields', () => {
+    const result = validateRequestBody({
+      song: {
+        ...baseSong,
+        album: 'Album',
+        artworkUrl: 'https://example.com/a.jpg',
+        previewUrl: 'https://example.com/p.m4a'
+      },
+      requester: {
+        name: 'Avery',
+        dedication: 'For the floor',
+        contact: '@avery'
+      }
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.song.album).toBe('Album');
+      expect(result.value.requester.name).toBe('Avery');
+      expect(result.value.requester.contact).toBe('@avery');
+    }
+  });
+
+  it('treats empty-string optional fields as null', () => {
+    const result = validateRequestBody({
+      song: { ...baseSong, album: '' },
+      requester: { dedication: '' }
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.song.album).toBeNull();
+      expect(result.value.requester.dedication).toBeNull();
+    }
+  });
+
+  it('rejects non-string optional fields', () => {
+    const result = validateRequestBody({
+      song: { ...baseSong, album: 42 }
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/song\.album must be a string/);
+  });
+});

--- a/netlify/functions/__tests__/request.test.ts
+++ b/netlify/functions/__tests__/request.test.ts
@@ -3,14 +3,23 @@ import type { Handler } from '@netlify/functions';
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import { handler as requestHandler } from '../request';
 import { FORM_FIELD_IDS } from '../../../shared/formFields';
+import { resetRateLimit } from '../_rateLimit';
 
 const handler = requestHandler as Handler;
+
+const makeEvent = (overrides: Record<string, unknown> = {}) =>
+  ({
+    httpMethod: 'POST',
+    headers: { 'x-forwarded-for': '1.1.1.1' },
+    ...overrides
+  }) as any;
 
 describe('request function', () => {
   const fetchMock = vi.fn();
   const originalEnv = process.env;
 
   beforeEach(() => {
+    resetRateLimit();
     vi.stubGlobal('fetch', fetchMock);
     process.env = {
       ...originalEnv,
@@ -33,7 +42,7 @@ describe('request function', () => {
 
   it('returns 400 when song payload is missing', async () => {
     const response = await handler(
-      { httpMethod: 'POST', body: JSON.stringify({}) } as any,
+      makeEvent({ body: JSON.stringify({}) }),
       {} as any
     );
 
@@ -41,12 +50,35 @@ describe('request function', () => {
     expect(JSON.parse(response.body).error).toMatch(/song information/i);
   });
 
+  it('returns 400 when song.id is missing', async () => {
+    const response = await handler(
+      makeEvent({
+        body: JSON.stringify({ song: { title: 'T', artist: 'A' } })
+      }),
+      {} as any
+    );
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.body).error).toBe('song.id is required');
+  });
+
+  it('returns 400 when song.artist is a number', async () => {
+    const response = await handler(
+      makeEvent({
+        body: JSON.stringify({ song: { id: '1', title: 'T', artist: 42 } })
+      }),
+      {} as any
+    );
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.body).error).toBe('song.artist is required');
+  });
+
   it('submits to the Google Form with normalized payload', async () => {
     fetchMock.mockResolvedValueOnce({ ok: true, status: 200 });
 
     const response = await handler(
-      {
-        httpMethod: 'POST',
+      makeEvent({
         body: JSON.stringify({
           song: {
             id: '123',
@@ -62,7 +94,7 @@ describe('request function', () => {
             contact: 'instagram.com/avery'
           }
         })
-      } as any,
+      }),
       {} as any
     );
 
@@ -90,15 +122,31 @@ describe('request function', () => {
     expect(JSON.parse(response.body).message).toMatch(/submitted successfully/i);
   });
 
+  it('accepts a payload without a requester block', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 200 });
+    const response = await handler(
+      makeEvent({
+        body: JSON.stringify({
+          song: { id: '1', title: 'T', artist: 'A' }
+        })
+      }),
+      {} as any
+    );
+
+    expect(response.statusCode).toBe(200);
+    const body = fetchMock.mock.calls[0][1]?.body as string;
+    const params = new URLSearchParams(body);
+    expect(params.get(FORM_FIELD_IDS.requesterName)).toBe('');
+  });
+
   it('uses ALLOWED_ORIGIN for CORS header on responses and OPTIONS', async () => {
     process.env.ALLOWED_ORIGIN = 'https://djrequests.example';
     fetchMock.mockResolvedValueOnce({ ok: true, status: 200 });
 
     const postResponse = await handler(
-      {
-        httpMethod: 'POST',
+      makeEvent({
         body: JSON.stringify({ song: { id: '1', title: 't', artist: 'a' } })
-      } as any,
+      }),
       {} as any
     );
     expect(postResponse.headers?.['access-control-allow-origin']).toBe(
@@ -119,20 +167,59 @@ describe('request function', () => {
     fetchMock.mockResolvedValueOnce({ ok: false, status: 500 });
 
     const response = await handler(
-      {
-        httpMethod: 'POST',
+      makeEvent({
         body: JSON.stringify({
-          song: {
-            id: '1',
-            title: 'Test',
-            artist: 'Artist'
-          }
+          song: { id: '1', title: 'Test', artist: 'Artist' }
         })
-      } as any,
+      }),
       {} as any
     );
 
     expect(response.statusCode).toBe(502);
     expect(JSON.parse(response.body).error).toMatch(/responded with status/i);
+  });
+
+  it('returns 429 with Retry-After after 5 rapid submissions from the same IP', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 200 });
+    const body = JSON.stringify({
+      song: { id: '1', title: 'T', artist: 'A' }
+    });
+
+    for (let i = 0; i < 5; i += 1) {
+      const ok = await handler(
+        makeEvent({ body, headers: { 'x-forwarded-for': '9.9.9.9' } }),
+        {} as any
+      );
+      expect(ok.statusCode).toBe(200);
+    }
+
+    const throttled = await handler(
+      makeEvent({ body, headers: { 'x-forwarded-for': '9.9.9.9' } }),
+      {} as any
+    );
+    expect(throttled.statusCode).toBe(429);
+    expect(throttled.headers?.['retry-after']).toBeDefined();
+    expect(Number(throttled.headers?.['retry-after'])).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shares the fallback "unknown" bucket when x-forwarded-for is missing', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 200 });
+    const body = JSON.stringify({
+      song: { id: '1', title: 'T', artist: 'A' }
+    });
+
+    for (let i = 0; i < 5; i += 1) {
+      const ok = await handler(
+        makeEvent({ body, headers: {} }),
+        {} as any
+      );
+      expect(ok.statusCode).toBe(200);
+    }
+
+    const throttled = await handler(
+      makeEvent({ body, headers: {} }),
+      {} as any
+    );
+    expect(throttled.statusCode).toBe(429);
   });
 });

--- a/netlify/functions/_rateLimit.ts
+++ b/netlify/functions/_rateLimit.ts
@@ -41,10 +41,15 @@ export const resetRateLimit = (): void => {
 export const resolveClientKey = (
   headers: Record<string, string | undefined>
 ): string => {
-  const forwarded = headers['x-forwarded-for'] ?? headers['X-Forwarded-For'];
+  const normalised: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    normalised[key.toLowerCase()] = value;
+  }
+
+  const forwarded = normalised['x-forwarded-for'];
   if (forwarded) {
     const first = forwarded.split(',')[0]?.trim();
     if (first) return first;
   }
-  return headers['client-ip'] ?? 'unknown';
+  return normalised['client-ip'] ?? 'unknown';
 };

--- a/netlify/functions/_rateLimit.ts
+++ b/netlify/functions/_rateLimit.ts
@@ -1,0 +1,50 @@
+// In-memory sliding-window rate limiter.
+//
+// Limitation: state is per-instance only — not shared across Netlify
+// function instances or cold starts. Entries are pruned lazily when the
+// same key is touched; there is no TTL sweep. Adequate for casual flood
+// protection (e.g. a single event) only.
+
+const WINDOW_MS = 60_000;
+const MAX_REQUESTS = 5;
+
+const hits = new Map<string, number[]>();
+
+export type RateLimitResult =
+  | { allowed: true }
+  | { allowed: false; retryAfterSeconds: number };
+
+export const checkRateLimit = (
+  key: string,
+  now: number = Date.now()
+): RateLimitResult => {
+  const windowStart = now - WINDOW_MS;
+  const existing = (hits.get(key) ?? []).filter((t) => t > windowStart);
+
+  if (existing.length >= MAX_REQUESTS) {
+    const retryAfterMs = existing[0] + WINDOW_MS - now;
+    return {
+      allowed: false,
+      retryAfterSeconds: Math.max(1, Math.ceil(retryAfterMs / 1000))
+    };
+  }
+
+  existing.push(now);
+  hits.set(key, existing);
+  return { allowed: true };
+};
+
+export const resetRateLimit = (): void => {
+  hits.clear();
+};
+
+export const resolveClientKey = (
+  headers: Record<string, string | undefined>
+): string => {
+  const forwarded = headers['x-forwarded-for'] ?? headers['X-Forwarded-For'];
+  if (forwarded) {
+    const first = forwarded.split(',')[0]?.trim();
+    if (first) return first;
+  }
+  return headers['client-ip'] ?? 'unknown';
+};

--- a/netlify/functions/_validate.ts
+++ b/netlify/functions/_validate.ts
@@ -1,0 +1,108 @@
+export type ValidatedSong = {
+  id: string;
+  title: string;
+  artist: string;
+  album: string | null;
+  artworkUrl: string | null;
+  previewUrl: string | null;
+};
+
+export type ValidatedRequester = {
+  name: string | null;
+  dedication: string | null;
+  contact: string | null;
+};
+
+export type ValidatedRequest = {
+  song: ValidatedSong;
+  requester: ValidatedRequester;
+};
+
+export type ValidationResult =
+  | { ok: true; value: ValidatedRequest }
+  | { ok: false; error: string };
+
+const MAX_STRING = 500;
+
+type StringOrError = string | { error: string };
+
+const requireString = (value: unknown, field: string): StringOrError => {
+  if (typeof value !== 'string') return { error: `${field} is required` };
+  const trimmed = value.trim();
+  if (!trimmed) return { error: `${field} is required` };
+  if (trimmed.length > MAX_STRING) return { error: `${field} is too long` };
+  return trimmed;
+};
+
+type OptionalStringOrError = string | null | { error: string };
+
+const optionalString = (value: unknown, field: string): OptionalStringOrError => {
+  if (value === undefined || value === null || value === '') return null;
+  if (typeof value !== 'string') return { error: `${field} must be a string` };
+  if (value.length > MAX_STRING) return { error: `${field} is too long` };
+  return value.trim() || null;
+};
+
+const isErrorResult = (value: unknown): value is { error: string } =>
+  typeof value === 'object' && value !== null && 'error' in value;
+
+export const validateRequestBody = (raw: unknown): ValidationResult => {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ok: false, error: 'Request body must be an object' };
+  }
+
+  const body = raw as Record<string, unknown>;
+  const song = body.song;
+
+  if (!song || typeof song !== 'object' || Array.isArray(song)) {
+    return { ok: false, error: 'Song information is required' };
+  }
+
+  const requesterRaw = body.requester;
+  const requester =
+    requesterRaw && typeof requesterRaw === 'object' && !Array.isArray(requesterRaw)
+      ? (requesterRaw as Record<string, unknown>)
+      : {};
+
+  const songObj = song as Record<string, unknown>;
+
+  const id = requireString(songObj.id, 'song.id');
+  if (isErrorResult(id)) return { ok: false, error: id.error };
+  const title = requireString(songObj.title, 'song.title');
+  if (isErrorResult(title)) return { ok: false, error: title.error };
+  const artist = requireString(songObj.artist, 'song.artist');
+  if (isErrorResult(artist)) return { ok: false, error: artist.error };
+
+  const album = optionalString(songObj.album, 'song.album');
+  if (isErrorResult(album)) return { ok: false, error: album.error };
+  const artworkUrl = optionalString(songObj.artworkUrl, 'song.artworkUrl');
+  if (isErrorResult(artworkUrl)) return { ok: false, error: artworkUrl.error };
+  const previewUrl = optionalString(songObj.previewUrl, 'song.previewUrl');
+  if (isErrorResult(previewUrl)) return { ok: false, error: previewUrl.error };
+
+  const name = optionalString(requester.name, 'requester.name');
+  if (isErrorResult(name)) return { ok: false, error: name.error };
+  const dedication = optionalString(requester.dedication, 'requester.dedication');
+  if (isErrorResult(dedication)) return { ok: false, error: dedication.error };
+  const contact = optionalString(requester.contact, 'requester.contact');
+  if (isErrorResult(contact)) return { ok: false, error: contact.error };
+
+  return {
+    ok: true,
+    value: {
+      song: {
+        id,
+        title,
+        artist,
+        album,
+        artworkUrl,
+        previewUrl
+      },
+      requester: {
+        name,
+        dedication,
+        contact
+      }
+    }
+  };
+};

--- a/netlify/functions/request.ts
+++ b/netlify/functions/request.ts
@@ -1,32 +1,19 @@
 import type { Handler } from '@netlify/functions';
 import { FORM_FIELD_IDS } from '../../shared/formFields';
 import { corsHeaders } from './_cors';
+import { checkRateLimit, resolveClientKey } from './_rateLimit';
+import { validateRequestBody } from './_validate';
 
-type SongPayload = {
-  id: string;
-  title: string;
-  artist: string;
-  album?: string | null;
-  artworkUrl?: string | null;
-  previewUrl?: string | null;
-};
-
-type RequesterPayload = {
-  name?: string;
-  dedication?: string;
-  contact?: string;
-};
-
-type RequestBody = {
-  song?: SongPayload;
-  requester?: RequesterPayload;
-};
-
-const jsonResponse = (statusCode: number, payload: Record<string, unknown>) => ({
+const jsonResponse = (
+  statusCode: number,
+  payload: Record<string, unknown>,
+  extraHeaders: Record<string, string> = {}
+) => ({
   statusCode,
   headers: {
     'content-type': 'application/json',
-    ...corsHeaders()
+    ...corsHeaders(),
+    ...extraHeaders
   },
   body: JSON.stringify(payload)
 });
@@ -87,17 +74,32 @@ export const handler: Handler = async (event) => {
     return jsonResponse(400, { error: 'Missing request body' });
   }
 
-  let payload: RequestBody;
+  const clientKey = resolveClientKey(
+    (event.headers ?? {}) as Record<string, string | undefined>
+  );
+  const limit = checkRateLimit(clientKey);
+  if (!limit.allowed) {
+    return jsonResponse(
+      429,
+      { error: 'Too many requests. Please wait a moment before trying again.' },
+      { 'retry-after': String(limit.retryAfterSeconds) }
+    );
+  }
+
+  let raw: unknown;
 
   try {
-    payload = JSON.parse(event.body);
+    raw = JSON.parse(event.body);
   } catch {
     return jsonResponse(400, { error: 'Invalid JSON payload' });
   }
 
-  if (!payload.song) {
-    return jsonResponse(400, { error: 'Song information is required' });
+  const validation = validateRequestBody(raw);
+  if (!validation.ok) {
+    return jsonResponse(400, { error: validation.error });
   }
+
+  const { song, requester } = validation.value;
 
   const formConfig = (() => {
     try {
@@ -112,15 +114,15 @@ export const handler: Handler = async (event) => {
   }
 
   const params = new URLSearchParams(formConfig.defaultParams);
-  appendField(params, FORM_FIELD_IDS.trackId, payload.song.id);
-  appendField(params, FORM_FIELD_IDS.trackName, payload.song.title);
-  appendField(params, FORM_FIELD_IDS.artistName, payload.song.artist);
-  appendField(params, FORM_FIELD_IDS.albumName, payload.song.album ?? '');
-  appendField(params, FORM_FIELD_IDS.artworkUrl, payload.song.artworkUrl ?? '');
-  appendField(params, FORM_FIELD_IDS.previewUrl, payload.song.previewUrl ?? '');
-  appendField(params, FORM_FIELD_IDS.requesterName, payload.requester?.name ?? '');
-  appendField(params, FORM_FIELD_IDS.dedication, payload.requester?.dedication ?? '');
-  appendField(params, FORM_FIELD_IDS.contact, payload.requester?.contact ?? '');
+  appendField(params, FORM_FIELD_IDS.trackId, song.id);
+  appendField(params, FORM_FIELD_IDS.trackName, song.title);
+  appendField(params, FORM_FIELD_IDS.artistName, song.artist);
+  appendField(params, FORM_FIELD_IDS.albumName, song.album);
+  appendField(params, FORM_FIELD_IDS.artworkUrl, song.artworkUrl);
+  appendField(params, FORM_FIELD_IDS.previewUrl, song.previewUrl);
+  appendField(params, FORM_FIELD_IDS.requesterName, requester.name);
+  appendField(params, FORM_FIELD_IDS.dedication, requester.dedication);
+  appendField(params, FORM_FIELD_IDS.contact, requester.contact);
   params.set('submit', 'Submit');
 
   let response: Response;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,35 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSongSearch } from './hooks/useSongSearch';
 import { submitSongRequest } from './lib/googleForm';
 import squirrelsImage from '../squirrels.jpeg';
 
+const SUBMIT_COOLDOWN_MS = 3000;
+
 function App() {
   const { query, setQuery, results, status, message, error } = useSongSearch();
   const [requestingSongId, setRequestingSongId] = useState<string | null>(null);
+  const [cooldownSongId, setCooldownSongId] = useState<string | null>(null);
   const [requestFeedback, setRequestFeedback] = useState<{
     type: 'success' | 'error';
     message: string;
   } | null>(null);
+  const cooldownTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (cooldownTimer.current) clearTimeout(cooldownTimer.current);
+    },
+    []
+  );
+
+  const startCooldown = (songId: string) => {
+    if (cooldownTimer.current) clearTimeout(cooldownTimer.current);
+    setCooldownSongId(songId);
+    cooldownTimer.current = setTimeout(() => {
+      setCooldownSongId(null);
+      cooldownTimer.current = null;
+    }, SUBMIT_COOLDOWN_MS);
+  };
 
   const handleRequest = async (songId: string) => {
     const song = results.find((item) => item.id === songId);
@@ -35,6 +55,7 @@ function App() {
       });
     } finally {
       setRequestingSongId(null);
+      startCooldown(songId);
     }
   };
 
@@ -112,9 +133,15 @@ function App() {
                 type="button"
                 className="request-button"
                 onClick={() => handleRequest(song.id)}
-                disabled={requestingSongId === song.id}
+                disabled={
+                  requestingSongId === song.id || cooldownSongId === song.id
+                }
               >
-                {requestingSongId === song.id ? 'Sending…' : `Request "${song.title}"`}
+                {requestingSongId === song.id
+                  ? 'Sending…'
+                  : cooldownSongId === song.id
+                    ? 'Just sent'
+                    : `Request "${song.title}"`}
               </button>
             </li>
           ))}


### PR DESCRIPTION
## Summary

- Adds a hand-rolled shape validator (`netlify/functions/_validate.ts`) that rejects malformed `{ song, requester }` payloads with a `400` and a specific error message instead of silently posting blanks to the Google Form.
- Adds an in-memory per-IP sliding-window rate limiter (`netlify/functions/_rateLimit.ts`, 5 req / 60 s) that returns `429` with a `Retry-After` header on flood. Limitation (per-instance, no cross-instance state) documented inline.
- Adds a short (~3 s) post-submit cooldown on the client Request button in `src/App.tsx` to guard against accidental double-taps.
- `requester.name` kept **optional** for now (the UI does not yet collect it) — tracked as follow-up #44.

## Test plan

- [x] Pre-commit hooks pass
- [x] `npm run lint` passes
- [x] 44 netlify-function unit tests pass (14 validator, 9 rate-limit, 10 request handler, 11 existing search)
- [x] Pre-existing `src/__tests__/SearchView.test.tsx` failure confirmed unrelated (plan #35)
- [ ] Manual: submit request in `netlify dev` → row lands in Google Doc
- [ ] Manual: burst 6 submissions → 6th returns 429 + Retry-After

## Follow-ups

- #44 — collect requester name in UI so backend can require it
- #45 — bound rate-limit Map with LRU / TTL sweep

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)