### PR TITLE
feat(request): collect requester name in UI and require server-side

### DIFF
--- a/docs/plan/issues/44_collect_requester_name_in_ui.md
+++ b/docs/plan/issues/44_collect_requester_name_in_ui.md
@@ -1,7 +1,7 @@
 # GitHub Issue #44: Collect requester name in UI so backend can require it
 
 **Issue:** [#44](https://github.com/denhamparry/djrequests/issues/44)
-**Status:** Planning
+**Status:** Reviewed (Approved)
 **Date:** 2026-04-16
 
 ## Problem Statement
@@ -167,7 +167,43 @@ npm run test:unit -- netlify/functions/__tests__/request.test.ts
   renders, types a search, expects the request button to be disabled; then
   types a name and expects it to become enabled.
 
-### Step 5: Regression check with full test suite
+### Step 5: Update `request.test.ts`
+
+**File:** `netlify/functions/__tests__/request.test.ts`
+
+Several tests submit song payloads without a `requester.name`, which will
+now fail validation with 400 instead of hitting the Google Form stub. Add
+`requester: { name: 'Test' }` to these bodies:
+
+- "accepts a payload without a requester block" → rename/repurpose as
+  "accepts a payload with only requester.name" (or drop and replace with
+  a "rejects missing requester.name" test that expects 400).
+- "uses ALLOWED_ORIGIN for CORS header on responses and OPTIONS" — add
+  requester.name to the POST body so it still reaches the Google Form.
+- "returns error when Google Form submission fails" — add requester.name.
+- "returns 429 with Retry-After after 5 rapid submissions" — add
+  requester.name to the shared body.
+- "shares the fallback 'unknown' bucket" — add requester.name.
+
+Add a new test: "returns 400 when requester.name is missing" that asserts
+the error message is `requester.name is required`.
+
+### Step 6: Update `tests/e2e/request.spec.ts`
+
+**File:** `tests/e2e/request.spec.ts`
+
+The e2e smoke test currently clicks the request button without typing a
+name. With the new UI gate the button will be disabled. Update the test
+to fill the requester name input before clicking:
+
+```ts
+await page.fill('input[aria-label="Your name"]', 'Avery');
+```
+
+Also extend the request-route assertion to check
+`body.requester.name === 'Avery'`.
+
+### Step 7: Regression check with full test suite
 
 **Testing:**
 
@@ -231,7 +267,11 @@ installed; the test at `tests/e2e/request.spec.ts` may need a name typed.
    and add new ones for required name.
 4. `src/__tests__/SearchView.test.tsx` — type a name in submit test, add
    disabled-without-name test.
-5. `docs/plan/issues/44_collect_requester_name_in_ui.md` — this plan.
+5. `netlify/functions/__tests__/request.test.ts` — add `requester.name`
+   to payloads that don't have it; add new test for missing-name rejection.
+6. `tests/e2e/request.spec.ts` — fill the "Your name" input before
+   clicking request; assert requester.name in the intercepted POST body.
+7. `docs/plan/issues/44_collect_requester_name_in_ui.md` — this plan.
 
 ## Related Issues and Tasks
 

--- a/docs/plan/issues/44_collect_requester_name_in_ui.md
+++ b/docs/plan/issues/44_collect_requester_name_in_ui.md
@@ -1,0 +1,286 @@
+# GitHub Issue #44: Collect requester name in UI so backend can require it
+
+**Issue:** [#44](https://github.com/denhamparry/djrequests/issues/44)
+**Status:** Planning
+**Date:** 2026-04-16
+
+## Problem Statement
+
+The `request` Netlify function validator (`netlify/functions/_validate.ts`)
+currently treats `requester.name` as optional because the UI
+(`src/App.tsx`) never collects it. Issue #32 originally listed
+`requester.name` as required. Until the UI collects it, anonymous
+(empty-name) rows keep landing in the Google Doc queue.
+
+### Current Behavior
+
+- `src/App.tsx` submits a request with `submitSongRequest(song)` — no
+  `requester` payload, so `requester.name` is always `undefined`.
+- `_validate.ts` uses `optionalString(requester.name, ...)` — accepts
+  missing/empty names without error.
+- Google Doc queue entries arrive without a requester name; the DJ cannot
+  tell who asked for what.
+
+### Expected Behavior
+
+- UI collects a requester name (and optionally a dedication) before the
+  request can be sent.
+- Backend validator requires `requester.name` — empty/whitespace/missing
+  returns a 400 with `requester.name is required`.
+- Google Doc queue entries all carry an identifiable requester name.
+
+## Current State Analysis
+
+### Relevant Code
+
+- `src/App.tsx` — single-page UI, inline request buttons (no modal despite
+  issue title's wording); calls `submitSongRequest(song)` with no details.
+- `src/lib/googleForm.ts` — `submitSongRequest(song, details: Requester = {})`
+  already accepts a requester payload; wiring is ready.
+- `netlify/functions/_validate.ts` — `optionalString` is used for
+  `requester.name`, `requester.dedication`, `requester.contact`. Switching
+  `name` to `requireString` tightens the rule.
+- `netlify/functions/request.ts` — no change needed; it forwards the
+  validated requester to the Google Form via
+  `FORM_FIELD_IDS.requesterName`.
+- `shared/types.ts` — `Requester.name` is `string | undefined` (optional).
+  Leave optional at the type level (frontend sends a string when present);
+  backend enforces at runtime.
+- `netlify/functions/__tests__/_validate.test.ts` — has tests for
+  optional requester fields; needs updating to expect `name` as required.
+- `src/__tests__/SearchView.test.tsx` — existing "submits the song
+  request" test does not provide a name; needs updating, plus a new test
+  for the required-name gate.
+
+### Related Context
+
+- Original issue #32 (backend validation + rate limiting) — the relaxation
+  to optional was a pragmatic compromise when #33/#44 were split out.
+- The UI has no modal today; the request is a direct per-row button.
+  The fix adds a single persistent name input (and optional dedication)
+  at the top of the results area rather than introducing a modal.
+
+## Solution Design
+
+### Approach
+
+1. Add a persistent "Your name" input (required) and optional "Dedication"
+   input to `src/App.tsx`, stored in component state.
+2. Disable the per-song request buttons while the name field is empty /
+   whitespace.
+3. Pass `{ name, dedication }` into `submitSongRequest` when clicking a
+   request button.
+4. Flip `requester.name` in `_validate.ts` from optional → required.
+5. Update and extend tests to cover both layers.
+
+### Why not a modal
+
+Issue #44's text references "the request modal" but the current UI has
+none — each result has its own inline request button. Adding a modal
+purely to collect a name is heavier than needed and diverges from the
+existing pattern. A persistent inline name field is less friction for
+guests at a party and keeps the diff small. The Google Form already
+accepts a `Requester Name` field; any layout is compatible.
+
+### Benefits
+
+- Eliminates empty-requester rows in the DJ queue.
+- Closes the remaining gap from #32 without changing the submission path.
+- Backend validator now matches the original #32 requirement.
+
+## Implementation Plan
+
+### Step 1: Add requester-name state and inputs to `src/App.tsx`
+
+**File:** `src/App.tsx`
+
+**Changes:**
+
+- Add `const [requesterName, setRequesterName] = useState('');` and
+  `const [dedication, setDedication] = useState('');`.
+- Render a `<label>`/`<input>` for "Your name" (required) above the search
+  input, and an optional "Dedication" input below it.
+- Compute `const trimmedName = requesterName.trim();` and
+  `const hasName = trimmedName.length > 0;`.
+- Disable each request button when `!hasName` (in addition to the existing
+  `requestingSongId` / `cooldownSongId` checks).
+- In `handleRequest`, early-return when `!hasName` and show a friendly
+  inline message (or rely on the button being disabled — prefer just
+  disabling, keep feedback surface small).
+- Change the `submitSongRequest(song)` call to
+  `submitSongRequest(song, { name: trimmedName, dedication: dedication.trim() || undefined })`.
+
+**Testing:**
+
+```bash
+npm run test:unit -- src/__tests__/SearchView.test.tsx
+```
+
+### Step 2: Tighten the backend validator
+
+**File:** `netlify/functions/_validate.ts`
+
+**Changes:**
+
+- Replace
+  `const name = optionalString(requester.name, 'requester.name');`
+  with `const name = requireString(requester.name, 'requester.name');`.
+- The resulting `requester.name` type becomes `string` (not `string | null`);
+  update the `ValidatedRequester` type to `name: string;` (keep
+  `dedication` and `contact` as `string | null`).
+- No change to `request.ts` is needed — `appendField` already accepts
+  `string | null | undefined`.
+
+**Testing:**
+
+```bash
+npm run test:unit -- netlify/functions/__tests__/_validate.test.ts
+npm run test:unit -- netlify/functions/__tests__/request.test.ts
+```
+
+### Step 3: Update `_validate.test.ts`
+
+**File:** `netlify/functions/__tests__/_validate.test.ts`
+
+**Changes:**
+
+- In "accepts minimal valid payload without requester", change expectation
+  from `ok: true` to `ok: false` with error matching `requester.name is required`.
+- In "treats empty-string optional fields as null", include a valid
+  `requester.name` so only the remaining optional fields are exercised.
+- Add a new test: "rejects missing requester.name".
+- Add a new test: "rejects whitespace-only requester.name".
+- Keep "accepts full payload with optional fields" as-is (already supplies
+  `name: 'Avery'`).
+
+### Step 4: Update `SearchView.test.tsx`
+
+**File:** `src/__tests__/SearchView.test.tsx`
+
+**Changes:**
+
+- Update the "submits the song request" test: after typing the search
+  term, also type a requester name into the new "Your name" field before
+  clicking the request button, and assert that the POSTed body includes
+  `requester.name`.
+- Add a new test: "disables request buttons until a name is entered" —
+  renders, types a search, expects the request button to be disabled; then
+  types a name and expects it to become enabled.
+
+### Step 5: Regression check with full test suite
+
+**Testing:**
+
+```bash
+npm run lint
+npm run test:unit
+npm run build
+```
+
+E2E smoke (`npm run test:e2e`) optional — requires Playwright browsers
+installed; the test at `tests/e2e/request.spec.ts` may need a name typed.
+
+## Testing Strategy
+
+### Unit Testing
+
+- `_validate.test.ts` covers: missing name, whitespace-only name,
+  happy path with name present.
+- `SearchView.test.tsx` covers: button disabled without name, submission
+  includes requester name.
+
+### Integration Testing
+
+**Test Case 1: Submit without name**
+
+1. Load app
+2. Search for a song
+3. Try clicking request button → button is disabled, no network call.
+
+**Test Case 2: Submit with name**
+
+1. Load app, type "Avery" into name field
+2. Search for a song
+3. Click request button
+4. Expect POST body to `/request` has `requester.name === 'Avery'`
+5. Expect success feedback.
+
+### Regression Testing
+
+- Search flow (`useSongSearch`) unchanged.
+- Rate limit behaviour unchanged.
+- iTunes function unchanged.
+
+## Success Criteria
+
+- [ ] UI has a visible "Your name" input.
+- [ ] Request buttons are disabled when name is empty/whitespace.
+- [ ] `submitSongRequest` is called with `{ name: ... }`.
+- [ ] `_validate.ts` rejects missing/empty `requester.name` with a 400.
+- [ ] `ValidatedRequester.name` is typed as `string`.
+- [ ] All existing tests pass; new tests added and passing.
+- [ ] `npm run lint`, `npm run test:unit`, `npm run build` all succeed.
+
+## Files Modified
+
+1. `src/App.tsx` — add name/dedication inputs, disable buttons, pass
+   requester details to submit call.
+2. `netlify/functions/_validate.ts` — require `requester.name`; tighten
+   `ValidatedRequester` type.
+3. `netlify/functions/__tests__/_validate.test.ts` — update existing tests
+   and add new ones for required name.
+4. `src/__tests__/SearchView.test.tsx` — type a name in submit test, add
+   disabled-without-name test.
+5. `docs/plan/issues/44_collect_requester_name_in_ui.md` — this plan.
+
+## Related Issues and Tasks
+
+### Depends On
+
+- None.
+
+### Blocks
+
+- None.
+
+### Related
+
+- #32 — original backend validation issue.
+- #33 — rate-limit follow-up.
+
+### Enables
+
+- DJ can reliably see who requested each track.
+
+## References
+
+- [GitHub Issue #44](https://github.com/denhamparry/djrequests/issues/44)
+- `netlify/functions/_validate.ts`
+- `src/App.tsx`
+
+## Notes
+
+### Key Insights
+
+- The UI is a single-page inline-button layout, not a modal — plan uses
+  persistent inputs rather than introducing a modal.
+- `submitSongRequest` already accepts a `Requester` payload, so the client
+  plumbing is a one-line change.
+
+### Alternative Approaches Considered
+
+1. **Introduce a request modal** — heavier UI change, not needed to satisfy
+   the issue's intent. ❌
+2. **Make name required in the shared `Requester` type** — would force
+   `submitSongRequest` callers/tests to supply a name at compile time, but
+   the type lives in `shared/types.ts` and is used both client-side (where
+   the UI guards it) and by the function (which re-validates at runtime).
+   Keeping the shared type permissive and enforcing in the validator is
+   simpler and matches the current codebase pattern. ❌
+3. **Inline name input, runtime validator tightening** — chosen. ✅
+
+### Best Practices
+
+- Keep UI validation (button disabled) and backend validation (400
+  response) both in place — defence in depth.
+- Preserve the MSW-based test pattern; no real network calls in tests.

--- a/netlify/functions/__tests__/_validate.test.ts
+++ b/netlify/functions/__tests__/_validate.test.ts
@@ -57,8 +57,11 @@ describe('validateRequestBody', () => {
     if (!result.ok) expect(result.error).toMatch(/too long/);
   });
 
-  it('accepts minimal valid payload without requester', () => {
-    const result = validateRequestBody({ song: baseSong });
+  it('accepts minimal valid payload with requester.name', () => {
+    const result = validateRequestBody({
+      song: baseSong,
+      requester: { name: 'Avery' }
+    });
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.value.song).toEqual({
@@ -70,16 +73,32 @@ describe('validateRequestBody', () => {
         previewUrl: null
       });
       expect(result.value.requester).toEqual({
-        name: null,
+        name: 'Avery',
         dedication: null,
         contact: null
       });
     }
   });
 
+  it('rejects missing requester.name', () => {
+    const result = validateRequestBody({ song: baseSong });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe('requester.name is required');
+  });
+
+  it('rejects whitespace-only requester.name', () => {
+    const result = validateRequestBody({
+      song: baseSong,
+      requester: { name: '   ' }
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe('requester.name is required');
+  });
+
   it('trims whitespace on required strings', () => {
     const result = validateRequestBody({
-      song: { id: '  1  ', title: ' Song ', artist: ' Artist ' }
+      song: { id: '  1  ', title: ' Song ', artist: ' Artist ' },
+      requester: { name: 'Avery' }
     });
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -121,7 +140,7 @@ describe('validateRequestBody', () => {
   it('treats empty-string optional fields as null', () => {
     const result = validateRequestBody({
       song: { ...baseSong, album: '' },
-      requester: { dedication: '' }
+      requester: { name: 'Avery', dedication: '' }
     });
     expect(result.ok).toBe(true);
     if (result.ok) {

--- a/netlify/functions/__tests__/request.test.ts
+++ b/netlify/functions/__tests__/request.test.ts
@@ -122,8 +122,7 @@ describe('request function', () => {
     expect(JSON.parse(response.body).message).toMatch(/submitted successfully/i);
   });
 
-  it('accepts a payload without a requester block', async () => {
-    fetchMock.mockResolvedValueOnce({ ok: true, status: 200 });
+  it('returns 400 when requester.name is missing', async () => {
     const response = await handler(
       makeEvent({
         body: JSON.stringify({
@@ -133,10 +132,27 @@ describe('request function', () => {
       {} as any
     );
 
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.body).error).toBe('requester.name is required');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('accepts a payload with only requester.name', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, status: 200 });
+    const response = await handler(
+      makeEvent({
+        body: JSON.stringify({
+          song: { id: '1', title: 'T', artist: 'A' },
+          requester: { name: 'Avery' }
+        })
+      }),
+      {} as any
+    );
+
     expect(response.statusCode).toBe(200);
     const body = fetchMock.mock.calls[0][1]?.body as string;
     const params = new URLSearchParams(body);
-    expect(params.get(FORM_FIELD_IDS.requesterName)).toBe('');
+    expect(params.get(FORM_FIELD_IDS.requesterName)).toBe('Avery');
   });
 
   it('uses ALLOWED_ORIGIN for CORS header on responses and OPTIONS', async () => {
@@ -145,7 +161,10 @@ describe('request function', () => {
 
     const postResponse = await handler(
       makeEvent({
-        body: JSON.stringify({ song: { id: '1', title: 't', artist: 'a' } })
+        body: JSON.stringify({
+          song: { id: '1', title: 't', artist: 'a' },
+          requester: { name: 'Avery' }
+        })
       }),
       {} as any
     );
@@ -169,7 +188,8 @@ describe('request function', () => {
     const response = await handler(
       makeEvent({
         body: JSON.stringify({
-          song: { id: '1', title: 'Test', artist: 'Artist' }
+          song: { id: '1', title: 'Test', artist: 'Artist' },
+          requester: { name: 'Avery' }
         })
       }),
       {} as any
@@ -182,7 +202,8 @@ describe('request function', () => {
   it('returns 429 with Retry-After after 5 rapid submissions from the same IP', async () => {
     fetchMock.mockResolvedValue({ ok: true, status: 200 });
     const body = JSON.stringify({
-      song: { id: '1', title: 'T', artist: 'A' }
+      song: { id: '1', title: 'T', artist: 'A' },
+      requester: { name: 'Avery' }
     });
 
     for (let i = 0; i < 5; i += 1) {
@@ -205,7 +226,8 @@ describe('request function', () => {
   it('shares the fallback "unknown" bucket when x-forwarded-for is missing', async () => {
     fetchMock.mockResolvedValue({ ok: true, status: 200 });
     const body = JSON.stringify({
-      song: { id: '1', title: 'T', artist: 'A' }
+      song: { id: '1', title: 'T', artist: 'A' },
+      requester: { name: 'Avery' }
     });
 
     for (let i = 0; i < 5; i += 1) {

--- a/netlify/functions/_validate.ts
+++ b/netlify/functions/_validate.ts
@@ -8,7 +8,7 @@ export type ValidatedSong = {
 };
 
 export type ValidatedRequester = {
-  name: string | null;
+  name: string;
   dedication: string | null;
   contact: string | null;
 };
@@ -80,7 +80,7 @@ export const validateRequestBody = (raw: unknown): ValidationResult => {
   const previewUrl = optionalString(songObj.previewUrl, 'song.previewUrl');
   if (isErrorResult(previewUrl)) return { ok: false, error: previewUrl.error };
 
-  const name = optionalString(requester.name, 'requester.name');
+  const name = requireString(requester.name, 'requester.name');
   if (isErrorResult(name)) return { ok: false, error: name.error };
   const dedication = optionalString(requester.dedication, 'requester.dedication');
   if (isErrorResult(dedication)) return { ok: false, error: dedication.error };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,8 @@ const SUBMIT_COOLDOWN_MS = 3000;
 
 function App() {
   const { query, setQuery, results, status, message, error } = useSongSearch();
+  const [requesterName, setRequesterName] = useState('');
+  const [dedication, setDedication] = useState('');
   const [requestingSongId, setRequestingSongId] = useState<string | null>(null);
   const [cooldownSongId, setCooldownSongId] = useState<string | null>(null);
   const [requestFeedback, setRequestFeedback] = useState<{
@@ -14,6 +16,9 @@ function App() {
     message: string;
   } | null>(null);
   const cooldownTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const trimmedName = requesterName.trim();
+  const hasName = trimmedName.length > 0;
 
   useEffect(
     () => () => {
@@ -33,15 +38,20 @@ function App() {
 
   const handleRequest = async (songId: string) => {
     const song = results.find((item) => item.id === songId);
-    if (!song) {
+    if (!song || !hasName) {
       return;
     }
+
+    const trimmedDedication = dedication.trim();
 
     setRequestingSongId(songId);
     setRequestFeedback(null);
 
     try {
-      await submitSongRequest(song);
+      await submitSongRequest(song, {
+        name: trimmedName,
+        dedication: trimmedDedication || undefined
+      });
       setRequestFeedback({
         type: 'success',
         message: `Request for "${song.title}" sent to the DJ queue.`
@@ -74,6 +84,31 @@ function App() {
           Search for a song by title, artist, or album and send it to the DJ booth.
         </p>
       </header>
+
+      <label className="input-label" htmlFor="requester-name">
+        <span className="label-text">Your name</span>
+        <input
+          id="requester-name"
+          aria-label="Your name"
+          placeholder="So the DJ knows who requested it"
+          value={requesterName}
+          autoComplete="name"
+          required
+          onChange={(event) => setRequesterName(event.target.value)}
+        />
+      </label>
+
+      <label className="input-label" htmlFor="dedication">
+        <span className="label-text">Dedication (optional)</span>
+        <input
+          id="dedication"
+          aria-label="Dedication"
+          placeholder="e.g. For Sam's birthday"
+          value={dedication}
+          autoComplete="off"
+          onChange={(event) => setDedication(event.target.value)}
+        />
+      </label>
 
       <label className="input-label" htmlFor="song-search">
         <span className="label-text">Search songs</span>
@@ -134,8 +169,11 @@ function App() {
                 className="request-button"
                 onClick={() => handleRequest(song.id)}
                 disabled={
-                  requestingSongId === song.id || cooldownSongId === song.id
+                  !hasName ||
+                  requestingSongId === song.id ||
+                  cooldownSongId === song.id
                 }
+                title={!hasName ? 'Enter your name to request a song' : undefined}
               >
                 {requestingSongId === song.id
                   ? 'Sending…'

--- a/src/__tests__/SearchView.test.tsx
+++ b/src/__tests__/SearchView.test.tsx
@@ -138,6 +138,7 @@ describe('Song search experience', () => {
         const body = await request.json();
         expect(body.song.id).toBe('321');
         expect(body.song.title).toBe('Digital Love');
+        expect(body.requester.name).toBe('Avery');
 
         return HttpResponse.json({ message: 'Song request submitted successfully.' });
       })
@@ -145,6 +146,7 @@ describe('Song search experience', () => {
 
     render(<App />);
 
+    await user.type(screen.getByLabelText(/Your name/i), 'Avery');
     await user.type(screen.getByLabelText(/Search songs/i), 'digital love');
 
     const requestButton = await screen.findByRole('button', {
@@ -156,5 +158,38 @@ describe('Song search experience', () => {
     expect(
       await screen.findByText(/Request for "Digital Love" sent to the DJ queue./i)
     ).toBeInTheDocument();
+  });
+
+  it('disables request buttons until a requester name is entered', async () => {
+    const user = userEvent.setup();
+
+    server.use(
+      http.get(searchEndpoint, () =>
+        HttpResponse.json({
+          tracks: [
+            {
+              id: '999',
+              title: 'One More Time',
+              artist: 'Daft Punk',
+              album: 'Discovery',
+              artworkUrl: null,
+              previewUrl: null
+            }
+          ]
+        })
+      )
+    );
+
+    render(<App />);
+
+    await user.type(screen.getByLabelText(/Search songs/i), 'daft punk');
+
+    const requestButton = await screen.findByRole('button', {
+      name: /Request "One More Time"/i
+    });
+    expect(requestButton).toBeDisabled();
+
+    await user.type(screen.getByLabelText(/Your name/i), 'Avery');
+    expect(requestButton).toBeEnabled();
   });
 });

--- a/tests/e2e/request.spec.ts
+++ b/tests/e2e/request.spec.ts
@@ -34,6 +34,7 @@ test('smoke: user can search and prepare a song request', async ({ page }) => {
     const body = request.postDataJSON();
     expect(body.song.id).toBe('321');
     expect(body.song.title).toBe('Digital Love');
+    expect(body.requester.name).toBe('Avery');
 
     return route.fulfill({
       status: 200,
@@ -44,6 +45,7 @@ test('smoke: user can search and prepare a song request', async ({ page }) => {
 
   await page.goto('/');
 
+  await page.fill('input[aria-label="Your name"]', 'Avery');
   await page.fill('input[aria-label="Search songs"]', 'digital love');
   await page.waitForTimeout(400);
 


### PR DESCRIPTION
## Summary

- Add required "Your name" input (and optional "Dedication" field) to the request UI; disable per-song request buttons until a name is entered.
- Pass `{ name, dedication }` through `submitSongRequest` to the Netlify function.
- Tighten `netlify/functions/_validate.ts` to require `requester.name`; `ValidatedRequester.name` flips from `string | null` to `string`.
- Update `_validate.test.ts`, `request.test.ts`, `SearchView.test.tsx`, and the Playwright e2e to supply `requester.name`; add new tests for the required-name gate.

Closes #44

Follow-ups filed as #51, #52, #53.

## Test plan

- [x] `npm run lint`
- [x] `npm run test:unit` — 52 tests pass (pre-existing `SearchView.test.tsx` MSW/jsdom load failure from #35 still present on `main`, not caused by this PR)
- [x] `npm run build`
- [ ] `npm run test:e2e` — needs Playwright browsers installed; updated to fill the name field

🤖 Generated with [Claude Code](https://claude.com/claude-code)