### PR TITLE
docs(claude): correct shared types note — shared/types.ts is source of truth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,7 +246,7 @@ To request a code review from Claude on any PR:
 ## File Structure Notes
 
 - **No `src/components/`** - All UI in `App.tsx` for simplicity (single-page app)
-- **Shared types** - Interfaces duplicated in functions/frontend due to Netlify isolation
+- **Shared types** - `shared/types.ts` is the single source of truth for cross-layer contracts (`Song`, `Requester`); both `src/` and `netlify/functions/` import from it, and the Netlify bundler (esbuild) pulls `shared/` files in transitively
 - **Test collocation** - Tests live in `__tests__/` subdirectories near source files
 - **TypeScript configs** - Split into `tsconfig.base.json`, `tsconfig.app.json`, `tsconfig.node.json` for different contexts (Vite, Node, Apps Script)
 

--- a/docs/plan/issues/048_docs_claude_md_shared_types_note.md
+++ b/docs/plan/issues/048_docs_claude_md_shared_types_note.md
@@ -1,0 +1,49 @@
+# GitHub Issue #48: docs — update CLAUDE.md note about shared types
+
+**Issue:** [#48](https://github.com/denhamparry/djrequests/issues/48)
+**Status:** Reviewed (Approved)
+**Branch:** denhamparry.co.uk/feat/gh-issue-048
+**Date:** 2026-04-16
+
+## Problem
+
+`CLAUDE.md` line 249 in the "File Structure Notes" section states:
+
+> **Shared types** - Interfaces duplicated in functions/frontend due to Netlify isolation
+
+This was disproven by PR #47 (issue #33). `shared/types.ts` now hosts `Song`
+and `Requester`, imported from both `src/` and `netlify/functions/`. The
+Netlify bundler (esbuild) pulls in `shared/` transitively, so there is no
+isolation problem. The stale note will mislead future contributors into
+duplicating types unnecessarily.
+
+## Change
+
+Replace the single bullet in `CLAUDE.md` under `## File Structure Notes`:
+
+- Before: `**Shared types** - Interfaces duplicated in functions/frontend due to Netlify isolation`
+- After: describe `shared/` as the single source of truth for cross-layer
+  types (`Song`, `Requester`), noting that esbuild bundles `shared/` files
+  transitively for Netlify functions.
+
+## Files Modified
+
+- `CLAUDE.md` — rewrite the "Shared types" bullet in "File Structure Notes"
+
+## Acceptance Criteria
+
+- Bullet no longer claims types are duplicated.
+- Bullet references `shared/types.ts` and the esbuild bundling behaviour.
+- No other sections altered.
+
+## Review Summary
+
+**Overall Assessment:** Approved
+
+Trivial documentation-only change. No code paths, tests, or runtime behaviour
+affected. Risk is limited to accuracy of the new wording, which matches the
+current state of `shared/types.ts`. Proceed directly to implementation.
+
+## Status
+
+Complete


### PR DESCRIPTION
## Summary

- Fix stale note in `CLAUDE.md` "File Structure Notes" that claimed shared types were duplicated between `src/` and `netlify/functions/`.
- PR #47 (issue #33) consolidated `Song` and `Requester` into `shared/types.ts`; both layers now import from it, and esbuild bundles `shared/` transitively for Netlify functions.
- Updated bullet points future contributors at the current reality so they don't re-introduce duplication.

## Test plan

- [x] Pre-commit hooks pass on changed files
- [x] No code paths affected (docs-only change)

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)