### PR TITLE
fix(request): log config errors server-side and redact client response

### DIFF
--- a/docs/plan/issues/050_log_config_errors_redact_client_response.md
+++ b/docs/plan/issues/050_log_config_errors_redact_client_response.md
@@ -1,0 +1,107 @@
+# GitHub Issue #50: log config errors server-side and redact details from client response
+
+**Issue:** [#50](https://github.com/denhamparry/djrequests/issues/50)
+**Status:** Planning
+**Branch:** denhamparry.co.uk/feat/gh-issue-050
+**Date:** 2026-04-16
+
+## Context
+
+In `netlify/functions/request.ts`, `deriveFormResponseConfig()` throws when
+`GOOGLE_FORM_URL` / `VITE_GOOGLE_FORM_URL` is missing or malformed. The catch
+block (lines 104–111) returns the raw `configError.message` to the client and
+never writes to `console.error`, so:
+
+1. **No operator trail.** A misconfigured deploy produces 500s with no log
+   entry, making it hard to diagnose from Netlify function logs.
+2. **Internal details leak to clients.** The thrown messages name the
+   environment variables (`"Set GOOGLE_FORM_URL or VITE_GOOGLE_FORM_URL."`)
+   and describe the expected URL shape. That is implementation detail that
+   should not reach end users.
+
+Surfaced during review of PR #47 — not introduced by that PR.
+
+## Approach
+
+In the config-error catch branch:
+
+- `console.error(...)` the original error (with a stable prefix so it is easy
+  to grep in Netlify logs), including the `Error` instance so the stack is
+  preserved.
+- Return a generic 500 response with a user-facing message that reveals
+  nothing about env vars or URL parsing:
+  `"Request service is temporarily unavailable."`
+
+No other error branches change. The network-failure (502) and non-OK Google
+Form response (502) branches already return shape-appropriate messages; the
+network branch does leak `networkError.message` but that is out of scope for
+this issue (operator-triggered config errors are the concern here).
+
+## Files Modified
+
+- `netlify/functions/request.ts` — add `console.error`, replace client-facing
+  message with a generic string.
+- `netlify/functions/__tests__/request.test.ts` — add a test covering the
+  missing-env-var case: asserts 500 status, generic message (no env var name
+  leak), and that `console.error` was called.
+
+## Implementation
+
+```ts
+let formConfig: ReturnType<typeof deriveFormResponseConfig>;
+try {
+  formConfig = deriveFormResponseConfig();
+} catch (configError) {
+  console.error('[request] Google Form configuration error:', configError);
+  return jsonResponse(500, {
+    error: 'Request service is temporarily unavailable.'
+  });
+}
+```
+
+## Tasks
+
+1. Add failing test in `request.test.ts` for missing `VITE_GOOGLE_FORM_URL`:
+   - Clear both `GOOGLE_FORM_URL` and `VITE_GOOGLE_FORM_URL` in the test.
+   - Spy on `console.error` and assert it was called once.
+   - Assert `response.statusCode === 500`.
+   - Assert response body message does **not** include "GOOGLE_FORM_URL" or
+     "VITE_GOOGLE_FORM_URL".
+   - Assert response body message matches "temporarily unavailable".
+2. Update `request.ts` to log and return the generic message.
+3. Run `npm run test:unit`, `npm run lint`, pre-commit.
+4. Commit + open PR.
+
+## Acceptance Criteria
+
+- Missing/invalid `GOOGLE_FORM_URL` produces a `console.error` entry in
+  Netlify logs.
+- Client response for the config-error path contains no env var names, URL
+  parsing hints, or the underlying `Error.message`.
+- Response status remains 500 (operator must still fix the deploy).
+- New test covers both the log side-effect and the redacted body.
+- Existing tests pass unchanged.
+
+## Out of Scope
+
+- Redacting the 502 network-error branch (`networkError.message` leak). A
+  separate issue if desired — the failure surface differs (transient upstream
+  vs. permanent misconfig).
+- Structured logging / observability stack (log shipping, metrics).
+- Changing the status code from 500 to something else.
+
+## Risks
+
+- **Very low.** Behaviour change is purely in the error-response body; status
+  code, headers, and happy-path unchanged.
+- One visible risk: if an operator was scraping the previous verbose message
+  out of the response body to diagnose, they lose that signal. Mitigated by
+  the new `console.error` — Netlify function logs are the correct place for
+  that detail.
+
+## References
+
+- [GitHub Issue #50](https://github.com/denhamparry/djrequests/issues/50)
+- Prior art for the pattern: existing 502 network-error branch already
+  returns a structured message; this change brings the 500 config branch in
+  line with "log details, return generic string".

--- a/docs/plan/issues/050_log_config_errors_redact_client_response.md
+++ b/docs/plan/issues/050_log_config_errors_redact_client_response.md
@@ -1,7 +1,7 @@
 # GitHub Issue #50: log config errors server-side and redact details from client response
 
 **Issue:** [#50](https://github.com/denhamparry/djrequests/issues/50)
-**Status:** Planning
+**Status:** Reviewed (Approved)
 **Branch:** denhamparry.co.uk/feat/gh-issue-050
 **Date:** 2026-04-16
 
@@ -105,3 +105,57 @@ try {
 - Prior art for the pattern: existing 502 network-error branch already
   returns a structured message; this change brings the 500 config branch in
   line with "log details, return generic string".
+
+## Plan Review
+
+**Reviewer:** Claude Code (workflow-research-plan)
+**Review Date:** 2026-04-16
+
+### Review Summary
+
+- **Overall Assessment:** Approved
+- **Confidence Level:** High
+- **Recommendation:** Proceed to implementation
+
+### Strengths
+
+- Scope matches the issue exactly: log + redact only, no adjacent refactors.
+- Out-of-scope section explicitly calls out the analogous 502 network-error
+  leak, acknowledging it without expanding scope.
+- Test plan asserts both sides of the change (side-effect logging + body
+  content), not just one.
+- Verified: `netlify/` has no existing `console.*` call sites, so adding the
+  first `console.error` needs no coordination with a shared logger
+  abstraction.
+
+### Verified Against Codebase
+
+- `netlify/functions/request.ts:104-111` — catch branch confirmed to return
+  `configError.message` verbatim. Replacement targets the correct lines.
+- `netlify/functions/__tests__/request.test.ts` — existing tests stub
+  `VITE_GOOGLE_FORM_URL` in `beforeEach`; the new missing-config test needs
+  to explicitly delete both env keys after the base setup.
+
+### Required Changes
+
+None.
+
+### Optional Improvements
+
+- In the new test, silence the spy with
+  `vi.spyOn(console, 'error').mockImplementation(() => {})` so the assertion
+  passes without polluting the test runner output. Minor quality-of-life,
+  non-blocking.
+
+### Verification Checklist
+
+- [x] Solution addresses root cause identified in GitHub issue
+- [x] All acceptance criteria from issue are covered (log + generic message)
+- [x] Implementation steps are specific and actionable
+- [x] File paths and code references are accurate
+- [x] Security implications considered (info-leak redaction is the point)
+- [x] Performance impact assessed (none — single `console.error` per 500)
+- [x] Test strategy covers critical paths and edge cases
+- [x] Documentation updates planned (none needed — internal behaviour)
+- [x] Related issues/dependencies identified (2XX network-error leak noted)
+- [x] Breaking changes documented (none — response shape preserved)

--- a/docs/plan/issues/050_log_config_errors_redact_client_response.md
+++ b/docs/plan/issues/050_log_config_errors_redact_client_response.md
@@ -1,7 +1,7 @@
 # GitHub Issue #50: log config errors server-side and redact details from client response
 
 **Issue:** [#50](https://github.com/denhamparry/djrequests/issues/50)
-**Status:** Reviewed (Approved)
+**Status:** Complete
 **Branch:** denhamparry.co.uk/feat/gh-issue-050
 **Date:** 2026-04-16
 

--- a/netlify/functions/__tests__/request.test.ts
+++ b/netlify/functions/__tests__/request.test.ts
@@ -182,6 +182,32 @@ describe('request function', () => {
     );
   });
 
+  it('logs config errors server-side and returns a generic client message', async () => {
+    delete process.env.GOOGLE_FORM_URL;
+    delete process.env.VITE_GOOGLE_FORM_URL;
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const response = await handler(
+      makeEvent({
+        body: JSON.stringify({
+          song: { id: '1', title: 'T', artist: 'A' },
+          requester: { name: 'Avery' }
+        })
+      }),
+      {} as any
+    );
+
+    expect(response.statusCode).toBe(500);
+    const body = JSON.parse(response.body);
+    expect(body.error).toBe('Request service is temporarily unavailable.');
+    expect(body.error).not.toMatch(/GOOGLE_FORM_URL/);
+    expect(body.error).not.toMatch(/VITE_GOOGLE_FORM_URL/);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+
   it('returns error when Google Form submission fails', async () => {
     fetchMock.mockResolvedValueOnce({ ok: false, status: 500 });
 

--- a/netlify/functions/request.ts
+++ b/netlify/functions/request.ts
@@ -105,8 +105,9 @@ export const handler: Handler = async (event) => {
   try {
     formConfig = deriveFormResponseConfig();
   } catch (configError) {
+    console.error('[request] Google Form configuration error:', configError);
     return jsonResponse(500, {
-      error: configError instanceof Error ? configError.message : 'Configuration error'
+      error: 'Request service is temporarily unavailable.'
     });
   }
 


### PR DESCRIPTION
## Summary

- `deriveFormResponseConfig()` catch branch no longer returns `configError.message` verbatim — the raw message named env vars (`GOOGLE_FORM_URL` / `VITE_GOOGLE_FORM_URL`) and URL parsing details, leaking internals to clients
- Added `console.error('[request] Google Form configuration error:', configError)` so Netlify function logs carry the operator trail that was previously absent
- Client now receives a generic 500 body: `"Request service is temporarily unavailable."` — status code preserved so deploy monitoring still triggers
- New unit test asserts both the log side-effect and the redacted body (no env var names in response)

## Test plan

- [x] `npm run test:unit` — all 58 tests pass (pre-existing `SearchView.test.tsx` setup failure is unrelated, tracked by #35)
- [x] `npm run lint` — clean
- [x] Pre-commit hooks pass
- [x] All acceptance criteria from issue #50 met

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)