### PR TITLE
feat(ui): add play-preview overlay on album artwork (#83)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,6 +212,20 @@ To request a code review from Claude on any PR:
 - **Doc ID comes from a Script Property** - Set `GOOGLE_DOC_ID` under Project Settings → Script Properties before first form submission. If unset or blank, `onFormSubmit` throws a clear error visible in the Executions log
 - **No local testing** - Use Vitest to test `format.ts` logic separately; Apps Script runtime can only be tested by submitting forms
 
+### Preview playback on iOS
+
+- The preview-overlay feature uses a native `<audio>` element. iOS silences
+  `<audio>` playback when the hardware ringer switch is set to silent, with
+  no visible feedback in the UI — users may think the feature is broken.
+  This is an accepted MVP limitation. The known workaround is to play the
+  preview through a hidden `<video playsinline>` element instead (video is
+  not subject to the ringer switch), to be considered only if users report it.
+- `HTMLMediaElement.play()` and `pause()` are not implemented in jsdom. Unit
+  tests in `src/__tests__/PreviewButton.test.tsx` use `vi.spyOn` on the
+  prototype with per-test restore. The Playwright smoke test in
+  `tests/e2e/request.spec.ts` uses `page.addInitScript` to stub them so
+  Chromium's autoplay heuristics don't interfere.
+
 ### Vitest on Node 22+
 
 - Node 22+ emits a benign `ExperimentalWarning: --localstorage-file was provided without a valid path` from jsdom 29's WebStorage shim. The `test:unit` / `test:watch` scripts set `NODE_OPTIONS=--no-warnings=ExperimentalWarning` to keep output clean while preserving `DeprecationWarning`s.

--- a/docs/plan/issues/83_preview_button_overlay_on_album_artwork.md
+++ b/docs/plan/issues/83_preview_button_overlay_on_album_artwork.md
@@ -1,0 +1,352 @@
+# GitHub Issue #83: feat(ui): add play-preview overlay on album artwork
+
+**Issue:** [#83](https://github.com/denhamparry/djrequests/issues/83)
+**Status:** Planning
+**Date:** 2026-04-16
+
+## Problem Statement
+
+The iTunes Search response already exposes a 30-second AAC preview URL per
+track (surfaced as `previewUrl` on each `Song` by
+`netlify/functions/search.ts`). Today this field is returned to the client
+but unused in the UI — guests have no way to sample a track before
+dispatching a request to the DJ.
+
+### Current Behavior
+
+- `src/App.tsx` renders each result with `<img>` artwork (56×56), song title,
+  meta line, and a `Request "…"` button.
+- `previewUrl` is read from the search response (and round-tripped to the
+  request submission) but never played anywhere.
+
+### Expected Behavior
+
+- When a track has a `previewUrl`, a circular play button overlays the
+  album artwork.
+- Tapping the overlay plays the 30-second preview inline.
+- Tapping again (or starting a preview for a different track) stops the
+  currently-playing preview — only one preview plays at a time.
+- The button toggles between play/pause icons and resets to play when the
+  audio ends.
+- Tracks without a `previewUrl` render the artwork without an overlay (no
+  disabled control).
+- Feature must feel good on mobile: 44×44 px tap target, proper aria
+  labels, `preload="none"` so scrolling doesn't burn data.
+
+## Current State Analysis
+
+### Relevant Code/Config
+
+- **`src/App.tsx`** (lines 154–190) — renders the `<ul class="results">`
+  list. Artwork is a plain `<img>` sibling of the request button. No click
+  handler on the card itself — `handleRequest` is bound to the dedicated
+  button, so bubbling from the overlay to the card is **not** a real
+  concern (despite the issue's wording). `e.stopPropagation()` is still
+  belt-and-braces defensive.
+- **`shared/types.ts`** — `Song.previewUrl: string | null`. Type already
+  correct; no change needed.
+- **`netlify/functions/search.ts`** — already normalises `previewUrl`.
+- **`src/styles.css`** — `.results img, .artwork-placeholder` is a 56×56
+  block at all breakpoints. Grid collapses to two rows on `max-width:
+  480px` with artwork on the left of row 1.
+
+### Related Context
+
+- Vitest config (`vite.config.ts`) uses jsdom. jsdom does **not**
+  implement `HTMLMediaElement.play()` / `pause()` / `load()` — calling
+  them in tests throws "Not implemented". We will stub these on the
+  prototype inside the test file (or a small `src/test/setup.ts` wired
+  via `setupFiles`).
+- MSW setup lives in `src/test/msw-server.ts` and is reused across tests.
+- No existing vitest `setupFiles` entry — we can add one or stub inline
+  in the new test file. Inline stubbing is lower-blast-radius; prefer it.
+- The existing `request.spec.ts` Playwright smoke test uses
+  `id=321 / title="Digital Love"` with a `previewUrl` — a good hook for
+  the e2e assertion we add.
+
+## Solution Design
+
+### Approach
+
+1. **Extract a `PreviewButton` component** under `src/components/` to
+   keep `App.tsx` readable. This is the project's first component under
+   `src/`; acceptable because CLAUDE.md notes the current
+   "no `src/components/`" rule is for simplicity, not a ban.
+2. **Single shared `<audio>` element** — held via `useRef` at `App.tsx`
+   level, plus `playingId: string | null` state. Starting a new preview
+   pauses the current audio, updates `src`, calls `play()`. This
+   trivially enforces the single-player invariant.
+3. **Artwork wrapper** — convert the `<img>` into a `<div class="artwork">`
+   containing the `<img>` plus (conditionally) a `<PreviewButton>`. The
+   placeholder branch also gains the same wrapper shape so the grid
+   column stays consistent.
+4. **Icons** — inline SVG play/pause triangles. Avoid adding an icon
+   dependency.
+5. **Loading state** — while `readyState < HAVE_FUTURE_DATA` after
+   `play()`, show a small spinner on the button. Implemented with a
+   `loadingId: string | null` that is set on `play()` and cleared on the
+   `playing` event (or on error).
+
+### Trade-offs
+
+- **Inline SVG vs icon lib**: inline keeps the bundle small and avoids a
+  new dep. ✅
+- **Per-card `<audio>` vs shared**: shared avoids N audio elements and
+  makes the invariant free. ✅
+- **`preload="none"` vs `preload="metadata"`**: none saves mobile data;
+  first play incurs a buffering moment (the loading spinner covers it). ✅
+- **iOS mute switch** — `<audio>` is silenced by the hardware ringer
+  switch with no visible feedback. Acceptable for MVP per the issue; a
+  `<video playsinline>` workaround is noted as a follow-up in the issue
+  itself. Document in CLAUDE.md "Known Issues".
+
+### Benefits
+
+- Uses existing `previewUrl` data with no API changes.
+- Accessibility: proper button semantics, aria labels, keyboard-reachable.
+- No new runtime deps.
+
+## Implementation Plan
+
+### Step 1: Add `PreviewButton` component
+
+**File:** `src/components/PreviewButton.tsx` (new)
+
+**Changes:**
+
+- Props: `{ state: 'idle' | 'loading' | 'playing'; trackLabel: string;
+  onClick: (e: React.MouseEvent) => void }`.
+- Renders `<button type="button" class="preview-button"
+  aria-label="Preview {trackLabel}" aria-pressed={state === 'playing'}>`
+  with inline SVG for play/pause and a small spinner for loading.
+- `onClick` calls `e.stopPropagation()` then `props.onClick(e)`.
+
+### Step 2: Wire shared audio + state in `App.tsx`
+
+**File:** `src/App.tsx`
+
+**Changes:**
+
+- Add `const audioRef = useRef<HTMLAudioElement | null>(null);` — we
+  create the element imperatively in a lazy-init `useEffect` to avoid
+  SSR concerns (none today, but keeps it isolated).
+- Add `const [playingId, setPlayingId] = useState<string | null>(null);`
+  and `const [loadingId, setLoadingId] = useState<string | null>(null);`.
+- `ensureAudio()` helper lazily creates `new Audio()`, sets
+  `preload = 'none'`, attaches `ended`, `pause`, `playing`, and `error`
+  listeners that clear `playingId`/`loadingId` as appropriate.
+- `togglePreview(song)`:
+  - If `playingId === song.id`: call `audio.pause()`, clear `playingId`.
+  - Else: if something else is playing, `audio.pause()`; set
+    `audio.src = song.previewUrl`; `setLoadingId(song.id)`;
+    `audio.play()` — handle rejection by clearing loadingId/playingId
+    and logging (no user-facing error for MVP).
+- Cleanup: on unmount, pause and nuke the audio element (existing
+  `useEffect` return).
+
+### Step 3: Render the overlay in the results list
+
+**File:** `src/App.tsx`
+
+**Changes:**
+
+- Replace the current `<img>` / placeholder ternary with a single
+  `<div class="artwork">` wrapper containing:
+  - the image (or placeholder),
+  - a conditional `<PreviewButton>` when `song.previewUrl` is truthy,
+    passing `state` derived from `playingId`/`loadingId` and
+    `onClick={() => togglePreview(song)}`.
+
+### Step 4: CSS for the overlay
+
+**File:** `src/styles.css`
+
+**Changes:**
+
+- Add `.artwork { position: relative; width: 56px; height: 56px; }` —
+  and update the `.results img, .artwork-placeholder` rule to keep
+  the 56×56 sizing (already correct).
+- `.preview-button`:
+  - `position: absolute; inset: 0; display: flex; align-items: center;
+    justify-content: center;` — centres the icon over the artwork.
+  - Minimum `width: 44px; height: 44px;` tap target via `min-width` /
+    `min-height` — the artwork is 56×56 so the visible target is
+    already ≥44.
+  - `border: 0; background: rgba(0, 0, 0, 0.45); color: #fff;
+    border-radius: inherit;` plus a subtle hover state.
+  - Focus ring: `outline: 2px solid #fff; outline-offset: -2px` on
+    `:focus-visible`.
+  - `.preview-button svg { width: 20px; height: 20px; }`.
+- `.preview-spinner { animation: spin 0.9s linear infinite; }` plus
+  `@keyframes spin`.
+- Mobile (`max-width: 480px`): no override needed; artwork stays 56×56.
+
+### Step 5: Stub jsdom `HTMLMediaElement` in new test file
+
+**File:** `src/__tests__/PreviewButton.test.tsx` (new)
+
+**Changes:**
+
+- `beforeAll` stubs `HTMLMediaElement.prototype.play` to a mock that
+  returns `Promise.resolve()` and synchronously dispatches a `playing`
+  event on the element. `pause` is stubbed to dispatch a `pause` event.
+  `load` to a no-op.
+- Cover these cases:
+  1. **Button hidden when no previewUrl** — render a result with
+     `previewUrl: null`, assert no `Preview …` button in the document.
+  2. **Button visible + toggles play/pause** — render a result with a
+     preview URL; click the button; assert `aria-pressed="true"` and
+     that `audio.src` was set; click again; assert `aria-pressed="false"`.
+  3. **Single-player invariant** — render two results, both with
+     `previewUrl`; click A; click B; assert A's button is idle and B's
+     is pressed.
+  4. **Ended event resets state** — dispatch an `ended` event on the
+     shared audio element; assert B's button returns to idle.
+  5. **Click does not submit request** — click preview on a result while
+     `requesterName` is set; assert no POST to `/.netlify/functions/request`
+     was made (MSW handler spy, or just assert the request-feedback
+     banner does not appear).
+
+### Step 6: Playwright smoke assertion
+
+**File:** `tests/e2e/request.spec.ts`
+
+**Changes:**
+
+- Extend the existing test (or add a new `test(...)` block) that, after
+  the search results are visible, clicks the preview button on the
+  `Digital Love` card and asserts `aria-pressed="true"`. No audio
+  playback assertion — Playwright running on Chromium with autoplay
+  permissions is flaky for real audio assertions and unnecessary for
+  this smoke.
+- Use `page.addInitScript` to stub `HTMLMediaElement.prototype.play`
+  to a resolved Promise that dispatches `playing`, so Chromium's
+  autoplay heuristics don't interfere.
+
+### Step 7: Document iOS mute caveat in CLAUDE.md
+
+**File:** `CLAUDE.md`
+
+**Changes:**
+
+- Under "Known Issues & Gotchas", add a new "Preview playback on iOS"
+  block noting that the hardware ringer switch silences `<audio>`
+  playback with no visible feedback, and that `<video playsinline>`
+  is the known workaround if users complain.
+
+## Testing Strategy
+
+### Unit Testing
+
+Covered by Step 5 above — 5 cases via Vitest + React Testing Library,
+with `HTMLMediaElement.prototype.play/pause/load` stubbed on the
+prototype.
+
+### Integration Testing
+
+**Test case 1: Preview + request co-exist**
+
+1. Name + search → results appear.
+2. Click preview on track A.
+3. Click `Request "A"`.
+4. Expect request POST to fire and feedback banner to show. Preview
+   button state is irrelevant to the request path.
+
+**Test case 2: Missing previewUrl does not break**
+
+1. Mock a search result with `previewUrl: null`.
+2. Assert artwork renders; assert no preview button in DOM.
+
+### Regression Testing
+
+- All existing `SearchView.test.tsx` cases must still pass. Notably:
+  - "shows results after a debounced search" — result has a
+    `previewUrl` so a preview button will now render; update the test
+    only if it breaks due to new button affecting `getByRole('button')`
+    disambiguation. (Request button is `name: /Request "…"/`, preview
+    is `name: /Preview …/` — unique.)
+  - "disables request buttons until a requester name is entered" — that
+    result has `previewUrl: null`; preview button should NOT render;
+    existing assertions stay green.
+- Playwright smoke: existing assertions must still pass with the new
+  DOM.
+
+## Success Criteria
+
+- [ ] `PreviewButton` component exists with play/pause/loading states
+- [ ] Single shared `<audio>` element; only one preview plays at a time
+- [ ] Overlay hidden when `previewUrl` is null
+- [ ] `aria-label="Preview {title}"` and `aria-pressed` set correctly
+- [ ] `preload="none"` on the audio element
+- [ ] Tap target ≥ 44×44
+- [ ] 5 new unit tests pass
+- [ ] Playwright smoke extended with preview toggle assertion
+- [ ] CLAUDE.md documents iOS mute caveat
+- [ ] `npm run lint && npm run test:unit && npm run test:e2e && npm run build` all green
+- [ ] pre-commit hooks pass
+
+## Files Modified
+
+1. `src/components/PreviewButton.tsx` — new component (inline SVG icons, aria)
+2. `src/App.tsx` — shared audio ref, playingId/loadingId state, artwork wrapper
+3. `src/styles.css` — `.artwork` wrapper, `.preview-button`, spinner keyframe
+4. `src/__tests__/PreviewButton.test.tsx` — new test file with jsdom stubs
+5. `tests/e2e/request.spec.ts` — add preview-click assertion + init script
+6. `CLAUDE.md` — iOS mute switch gotcha
+7. `docs/plan/issues/83_preview_button_overlay_on_album_artwork.md` — this plan
+
+## Related Issues and Tasks
+
+### Depends On
+
+- None. `previewUrl` already plumbed end-to-end.
+
+### Related
+
+- #83 (this) — issue.
+- Out-of-scope follow-ups listed in the issue (progress ring, waveform,
+  hover-autoplay, offline cache).
+
+### Enables
+
+- Future UX: progress scrubber, per-preview analytics, offline preview cache.
+
+## References
+
+- [GitHub Issue #83](https://github.com/denhamparry/djrequests/issues/83)
+- [MDN: HTMLMediaElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement)
+- [Apple HIG: tap targets](https://developer.apple.com/design/human-interface-guidelines/accessibility)
+- jsdom issue on HTMLMediaElement: stubbing
+  `HTMLMediaElement.prototype.{play,pause,load}` is the well-known workaround.
+
+## Notes
+
+### Key Insights
+
+- The issue text mentions "overlay tap must not bubble to the card (which
+  opens the request modal)" — but the current UI has no modal and no
+  card-level click handler. The request is triggered via a dedicated
+  button. We'll still `stopPropagation` on the overlay as a defensive
+  measure, but the concern is theoretical, not current-state.
+- `HTMLMediaElement.play()` returns a Promise that can reject (autoplay
+  policy, aborted by subsequent `pause`). Always attach `.catch()` —
+  unhandled rejection noise in prod is a smell.
+
+### Alternative Approaches Considered
+
+1. **Per-card `<audio>` element** — simpler render but requires manual
+   bookkeeping to pause siblings on play. Rejected — more state, same
+   net effect. ❌
+2. **Auto-play on card hover (desktop)** — fun but annoying; explicitly
+   ruled out of scope by the issue. ❌
+3. **Native `<audio controls>` element in the card** — ugly, takes
+   significant space, no mobile polish. ❌
+4. **Single shared audio + playingId state** — chosen. ✅
+
+### Best Practices
+
+- Set `audio.preload = 'none'` to avoid preloading 20 previews on scroll.
+- Handle `ended`, `pause`, `error` on the shared audio to keep UI state
+  in sync with media state (media is source of truth).
+- Always await/catch `audio.play()` to tolerate autoplay rejections.
+- Keep SVG icons inline — no dep additions.

--- a/docs/plan/issues/83_preview_button_overlay_on_album_artwork.md
+++ b/docs/plan/issues/83_preview_button_overlay_on_album_artwork.md
@@ -1,7 +1,7 @@
 # GitHub Issue #83: feat(ui): add play-preview overlay on album artwork
 
 **Issue:** [#83](https://github.com/denhamparry/djrequests/issues/83)
-**Status:** Reviewed (Approved)
+**Status:** Complete
 **Date:** 2026-04-16
 
 ## Problem Statement
@@ -468,13 +468,13 @@ prototype.
 
 **Must be made during implementation:**
 
-- [ ] aria-label includes both title AND artist
-- [ ] Use `vi.spyOn(...).mockRestore()` or a scoped setup file for
+- [x] aria-label includes both title AND artist
+- [x] Use `vi.spyOn(...).mockRestore()` or a scoped setup file for
       HTMLMediaElement stubs — do not permanently mutate the prototype
-- [ ] Add results-change effect that pauses audio and clears
+- [x] Add results-change effect that pauses audio and clears
       `playingId` when the currently-playing track drops out of
       results
-- [ ] The `audio.play()` `.catch()` must silently swallow `AbortError`
+- [x] The `audio.play()` `.catch()` must silently swallow `AbortError`
 
 ### Optional Improvements
 

--- a/docs/plan/issues/83_preview_button_overlay_on_album_artwork.md
+++ b/docs/plan/issues/83_preview_button_overlay_on_album_artwork.md
@@ -1,7 +1,7 @@
 # GitHub Issue #83: feat(ui): add play-preview overlay on album artwork
 
 **Issue:** [#83](https://github.com/denhamparry/djrequests/issues/83)
-**Status:** Planning
+**Status:** Reviewed (Approved)
 **Date:** 2026-04-16
 
 ## Problem Statement
@@ -350,3 +350,153 @@ prototype.
   in sync with media state (media is source of truth).
 - Always await/catch `audio.play()` to tolerate autoplay rejections.
 - Keep SVG icons inline — no dep additions.
+
+## Plan Review
+
+**Reviewer:** Claude Code (workflow-research-plan)
+**Review Date:** 2026-04-16
+**Original Plan Date:** 2026-04-16
+
+### Review Summary
+
+- **Overall Assessment:** Approved (with required refinements)
+- **Confidence Level:** High
+- **Recommendation:** Proceed to implementation; address Required Changes
+  during Phase 3 (they do not require plan re-revision)
+
+### Strengths
+
+- Correctly identifies that the existing UI has **no card-level click
+  handler or modal** — the issue's wording about "bubbling to the card
+  which opens the request modal" is a phantom concern, and the plan
+  names that out loud while still keeping `stopPropagation` as a
+  defensive measure.
+- Single-shared-`<audio>` + `playingId` state is the right architectural
+  call; it makes the single-player invariant free and avoids 20 audio
+  elements on scroll.
+- Test strategy correctly anticipates the jsdom
+  `HTMLMediaElement.play()` gap.
+- Playwright config already includes `mobile-chrome` (Pixel 5), so the
+  smoke extension gets mobile coverage for free — worth noting.
+- `preload="none"` chosen correctly for mobile data friendliness.
+- Scope is tight; all issue out-of-scope items (progress ring, waveform,
+  hover-autoplay, offline cache) are deferred.
+
+### Gaps Identified
+
+1. **Gap 1:** aria-label uses only `{title}`, but the issue asks for
+   `Preview {track} by {artist}`.
+   - **Impact:** Medium (accessibility + disambiguation when two tracks
+     share a title).
+   - **Recommendation:** Include both title and artist in the aria-label.
+
+2. **Gap 2:** Prototype-level stubbing of
+   `HTMLMediaElement.prototype.play/pause/load` pollutes every other
+   test in the same Vitest process.
+   - **Impact:** Medium (could mask regressions in unrelated tests that
+     happen to exercise media, however unlikely in this codebase).
+   - **Recommendation:** Use `vi.spyOn(HTMLMediaElement.prototype, 'play')`
+     and `.mockRestore()` in `afterEach`, OR move the stubs into a
+     dedicated `src/test/setup.ts` wired via `test.setupFiles`. Either
+     is fine; spy + restore is lower-blast-radius.
+
+3. **Gap 3:** No explicit handling for the "`play()` was interrupted by
+   a call to `pause()`" `AbortError` that fires when users tap rapidly.
+   - **Impact:** Low (noisy console in prod, not a functional bug).
+   - **Recommendation:** The plan's `.catch()` on `audio.play()` must
+     swallow `name === 'AbortError'` silently; everything else gets
+     `console.warn`.
+
+### Edge Cases Not Covered
+
+1. **Edge case 1:** Search results re-render with a different track list
+   while a preview is playing (e.g. the user types a new query).
+   - **Current Plan:** Not addressed — the audio element keeps playing
+     because `playingId` still points at a song no longer in `results`.
+   - **Recommendation:** Add a `useEffect` in `App.tsx` watching
+     `[results]` that, if `playingId` is set and the track is no longer
+     in `results`, pauses the audio and clears `playingId`.
+
+2. **Edge case 2:** Audio network error (offline, 404 on preview CDN).
+   - **Current Plan:** Silent clear on the `error` event.
+   - **Recommendation:** MVP silent-clear is acceptable (request flow
+     still works). Optionally surface a brief error icon — not
+     required.
+
+3. **Edge case 3:** Playwright `addInitScript` stub must both resolve
+   the play Promise AND dispatch the `playing` event on the element;
+   otherwise `loadingId` never clears in the real DOM.
+   - **Current Plan:** Mentions `dispatches 'playing'` for Vitest but
+     less explicit for Playwright.
+   - **Recommendation:** Spell out the Playwright stub payload in
+     Step 6 (`const p = HTMLMediaElement.prototype.play; ... dispatchEvent(new Event('playing'))`).
+
+### Alternatives Considered (Review)
+
+1. **Alternative: native `<audio controls>` inline in each card.**
+   - **Pros:** Zero custom state, full accessibility for free.
+   - **Cons:** ~30px tall, clashes with card visual design, inconsistent
+     cross-browser styling.
+   - **Verdict:** Plan's custom-button choice is correct. ✅
+
+2. **Alternative: dedicated `useAudioPreview` hook.**
+   - **Pros:** Extracts audio state/ref, reusable later.
+   - **Cons:** Over-engineered for one consumer.
+   - **Verdict:** Keep state in `App.tsx`; extract only if reused. ✅
+
+### Risks and Concerns
+
+1. **Risk: visual obstruction of album art.**
+   - **Likelihood:** Medium (semi-transparent full-cover overlay could
+     hide artwork detail).
+   - **Impact:** Low (aesthetic).
+   - **Mitigation:** Consider a smaller corner button (28×28 visual,
+     44×44 tap target via padding) rather than a full-cover overlay.
+     Revisit during CSS implementation.
+
+2. **Risk: autoplay policy rejection on first interaction.**
+   - **Likelihood:** Low (click handler counts as user gesture).
+   - **Impact:** Low (`.catch()` handles it).
+   - **Mitigation:** Already planned.
+
+3. **Risk: iOS ringer switch silencing with no feedback.**
+   - **Likelihood:** High for iPhone users with silenced phones.
+   - **Impact:** Low–Medium (user confusion).
+   - **Mitigation:** Already planned — documented in CLAUDE.md.
+
+### Required Changes
+
+**Must be made during implementation:**
+
+- [ ] aria-label includes both title AND artist
+- [ ] Use `vi.spyOn(...).mockRestore()` or a scoped setup file for
+      HTMLMediaElement stubs — do not permanently mutate the prototype
+- [ ] Add results-change effect that pauses audio and clears
+      `playingId` when the currently-playing track drops out of
+      results
+- [ ] The `audio.play()` `.catch()` must silently swallow `AbortError`
+
+### Optional Improvements
+
+- [ ] Smaller corner button (28×28 visual, 44×44 tap target) to avoid
+      obscuring artwork — revisit during CSS implementation
+- [ ] Extract a `useAudioPreview` hook if/when a second consumer lands
+- [ ] Brief error icon on preview network failure (2s auto-dismiss)
+      instead of silent clear
+
+### Verification Checklist
+
+- [x] Solution addresses root cause identified in GitHub issue
+- [x] All acceptance criteria from issue are covered
+- [x] Implementation steps are specific and actionable
+- [x] File paths and code references are accurate
+- [x] Security implications considered (no XSS risk — all data from
+      our own search function)
+- [x] Performance impact assessed (`preload="none"` prevents N×media fetches)
+- [x] Test strategy covers critical paths and edge cases (after
+      Required Changes)
+- [x] Documentation updates planned (CLAUDE.md iOS caveat)
+- [x] Related issues/dependencies identified
+- [x] Breaking changes documented (none)
+
+**Status change:** Planning → Reviewed (Approved)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { useSongSearch } from './hooks/useSongSearch';
 import { RequestError, submitSongRequest } from './lib/googleForm';
+import PreviewButton, { type PreviewState } from './components/PreviewButton';
+import type { Song } from '../shared/types';
 import squirrelsImage from '../squirrels.jpeg';
 
 const SUBMIT_COOLDOWN_MS = 3000;
@@ -15,17 +17,85 @@ function App() {
     type: 'success' | 'error';
     message: string;
   } | null>(null);
+  const [playingSongId, setPlayingSongId] = useState<string | null>(null);
+  const [loadingSongId, setLoadingSongId] = useState<string | null>(null);
   const cooldownTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
 
   const trimmedName = requesterName.trim();
   const hasName = trimmedName.length > 0;
 
+  const ensureAudio = (): HTMLAudioElement => {
+    if (audioRef.current) return audioRef.current;
+    const audio = new Audio();
+    audio.preload = 'none';
+    audio.addEventListener('playing', () => setLoadingSongId(null));
+    audio.addEventListener('ended', () => {
+      setPlayingSongId(null);
+      setLoadingSongId(null);
+    });
+    audio.addEventListener('pause', () => setLoadingSongId(null));
+    audio.addEventListener('error', () => {
+      setPlayingSongId(null);
+      setLoadingSongId(null);
+    });
+    audioRef.current = audio;
+    return audio;
+  };
+
+  const togglePreview = (song: Song) => {
+    if (!song.previewUrl) return;
+    const audio = ensureAudio();
+
+    if (playingSongId === song.id) {
+      audio.pause();
+      setPlayingSongId(null);
+      setLoadingSongId(null);
+      return;
+    }
+
+    audio.pause();
+    audio.src = song.previewUrl;
+    setPlayingSongId(song.id);
+    setLoadingSongId(song.id);
+    audio.play().catch((err: unknown) => {
+      if (err instanceof Error && err.name === 'AbortError') return;
+      setPlayingSongId(null);
+      setLoadingSongId(null);
+      if (err instanceof Error) {
+        console.warn('Preview playback failed:', err.message);
+      }
+    });
+  };
+
   useEffect(
     () => () => {
       if (cooldownTimer.current) clearTimeout(cooldownTimer.current);
+      const audio = audioRef.current;
+      if (audio) {
+        audio.pause();
+        audio.src = '';
+        audioRef.current = null;
+      }
     },
     []
   );
+
+  useEffect(() => {
+    if (!playingSongId) return;
+    const stillPresent = results.some((song) => song.id === playingSongId);
+    if (!stillPresent) {
+      audioRef.current?.pause();
+      setPlayingSongId(null);
+      setLoadingSongId(null);
+    }
+  }, [results, playingSongId]);
+
+  const previewStateFor = (songId: string): PreviewState => {
+    if (loadingSongId === songId) return 'loading';
+    if (playingSongId === songId) return 'playing';
+    return 'idle';
+  };
 
   const startCooldown = (songId: string) => {
     if (cooldownTimer.current) clearTimeout(cooldownTimer.current);
@@ -155,11 +225,20 @@ function App() {
         <ul className="results" aria-live="polite">
           {results.map((song) => (
             <li key={song.id}>
-              {song.artworkUrl ? (
-                <img src={song.artworkUrl} alt="" width={56} height={56} />
-              ) : (
-                <div className="artwork-placeholder" aria-hidden />
-              )}
+              <div className="artwork">
+                {song.artworkUrl ? (
+                  <img src={song.artworkUrl} alt="" width={56} height={56} />
+                ) : (
+                  <div className="artwork-placeholder" aria-hidden />
+                )}
+                {song.previewUrl && (
+                  <PreviewButton
+                    state={previewStateFor(song.id)}
+                    trackLabel={`${song.title} by ${song.artist}`}
+                    onClick={() => togglePreview(song)}
+                  />
+                )}
+              </div>
               <div>
                 <p className="song-title">{song.title}</p>
                 <p className="song-meta">

--- a/src/__tests__/PreviewButton.test.tsx
+++ b/src/__tests__/PreviewButton.test.tsx
@@ -1,0 +1,133 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import App from '../App';
+import { server } from '../test/msw-server';
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const searchEndpoint = '/.netlify/functions/search';
+
+type TrackArg = {
+  id?: string;
+  title?: string;
+  artist?: string;
+  artworkUrl?: string | null;
+  previewUrl?: string | null;
+};
+
+const track = (overrides: TrackArg = {}) => ({
+  id: '1',
+  title: 'Song One',
+  artist: 'Artist A',
+  album: null,
+  artworkUrl: null,
+  previewUrl: 'https://example.com/preview1.m4a',
+  ...overrides
+});
+
+const renderWithTracks = async (
+  tracks: ReturnType<typeof track>[],
+  searchTerm = 'anything'
+) => {
+  server.use(http.get(searchEndpoint, () => HttpResponse.json({ tracks })));
+  const user = userEvent.setup();
+  render(<App />);
+  await user.type(screen.getByLabelText(/Search songs/i), searchTerm);
+  // Wait for results to render by waiting for the first song title
+  await screen.findByText(tracks[0].title);
+  return { user };
+};
+
+describe('Preview button', () => {
+  let playSpy: ReturnType<typeof vi.spyOn>;
+  let pauseSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    playSpy = vi
+      .spyOn(HTMLMediaElement.prototype, 'play')
+      .mockImplementation(function (this: HTMLMediaElement) {
+        queueMicrotask(() => this.dispatchEvent(new Event('playing')));
+        return Promise.resolve();
+      });
+    pauseSpy = vi
+      .spyOn(HTMLMediaElement.prototype, 'pause')
+      .mockImplementation(function (this: HTMLMediaElement) {
+        this.dispatchEvent(new Event('pause'));
+      });
+  });
+
+  afterEach(() => {
+    playSpy.mockRestore();
+    pauseSpy.mockRestore();
+  });
+
+  it('hides the preview button when the track has no previewUrl', async () => {
+    await renderWithTracks([track({ previewUrl: null })]);
+    expect(screen.queryByRole('button', { name: /Preview Song One/i })).not.toBeInTheDocument();
+  });
+
+  it('renders the preview button when previewUrl is present', async () => {
+    await renderWithTracks([track()]);
+    const btn = screen.getByRole('button', { name: /Preview Song One by Artist A/i });
+    expect(btn).toBeInTheDocument();
+    expect(btn).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('toggles play and pause on click', async () => {
+    const { user } = await renderWithTracks([track()]);
+    const btn = screen.getByRole('button', { name: /Preview Song One by Artist A/i });
+
+    await user.click(btn);
+    expect(playSpy).toHaveBeenCalledTimes(1);
+    // After the playing event fires (via queueMicrotask), aria-pressed becomes true
+    await vi.waitFor(() => expect(btn).toHaveAttribute('aria-pressed', 'true'));
+
+    await user.click(btn);
+    expect(pauseSpy).toHaveBeenCalled();
+    await vi.waitFor(() => expect(btn).toHaveAttribute('aria-pressed', 'false'));
+  });
+
+  it('enforces single-player invariant across tracks', async () => {
+    const { user } = await renderWithTracks([
+      track({ id: '1', title: 'Song One' }),
+      track({ id: '2', title: 'Song Two', previewUrl: 'https://example.com/preview2.m4a' })
+    ]);
+
+    const btn1 = screen.getByRole('button', { name: /Preview Song One/i });
+    const btn2 = screen.getByRole('button', { name: /Preview Song Two/i });
+
+    await user.click(btn1);
+    await vi.waitFor(() => expect(btn1).toHaveAttribute('aria-pressed', 'true'));
+
+    await user.click(btn2);
+    await vi.waitFor(() => expect(btn2).toHaveAttribute('aria-pressed', 'true'));
+    expect(btn1).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('clicking the preview button does not trigger a song request', async () => {
+    const user = userEvent.setup();
+    const requestSpy = vi.fn();
+    server.use(
+      http.get(searchEndpoint, () => HttpResponse.json({ tracks: [track()] })),
+      http.post('/.netlify/functions/request', () => {
+        requestSpy();
+        return HttpResponse.json({ message: 'ok' });
+      })
+    );
+
+    render(<App />);
+    await user.type(screen.getByLabelText(/Your name/i), 'Avery');
+    await user.type(screen.getByLabelText(/Search songs/i), 'anything');
+    const previewBtn = await screen.findByRole('button', {
+      name: /Preview Song One by Artist A/i
+    });
+    await user.click(previewBtn);
+
+    expect(requestSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/PreviewButton.tsx
+++ b/src/components/PreviewButton.tsx
@@ -1,0 +1,72 @@
+import type { MouseEvent } from 'react';
+
+export type PreviewState = 'idle' | 'loading' | 'playing';
+
+type Props = {
+  state: PreviewState;
+  trackLabel: string;
+  onClick: () => void;
+};
+
+function PreviewButton({ state, trackLabel, onClick }: Props) {
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    onClick();
+  };
+
+  return (
+    <button
+      type="button"
+      className="preview-button"
+      aria-label={`Preview ${trackLabel}`}
+      aria-pressed={state === 'playing'}
+      data-state={state}
+      onClick={handleClick}
+    >
+      {state === 'loading' ? (
+        <svg
+          className="preview-spinner"
+          viewBox="0 0 24 24"
+          width="20"
+          height="20"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <circle
+            cx="12"
+            cy="12"
+            r="9"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeDasharray="14 42"
+          />
+        </svg>
+      ) : state === 'playing' ? (
+        <svg
+          viewBox="0 0 24 24"
+          width="20"
+          height="20"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <rect x="7" y="6" width="3.5" height="12" rx="1" fill="currentColor" />
+          <rect x="13.5" y="6" width="3.5" height="12" rx="1" fill="currentColor" />
+        </svg>
+      ) : (
+        <svg
+          viewBox="0 0 24 24"
+          width="20"
+          height="20"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <path d="M8 5.5v13l11-6.5-11-6.5Z" fill="currentColor" />
+        </svg>
+      )}
+    </button>
+  );
+}
+
+export default PreviewButton;

--- a/src/styles.css
+++ b/src/styles.css
@@ -106,6 +106,12 @@ input {
   box-shadow: 0 10px 25px rgba(0, 0, 0, 0.6);
 }
 
+.artwork {
+  position: relative;
+  width: 56px;
+  height: 56px;
+}
+
 .results img,
 .artwork-placeholder {
   width: 56px;
@@ -113,6 +119,45 @@ input {
   border-radius: 0.75rem;
   object-fit: cover;
   background: rgba(255, 255, 255, 0.08);
+  display: block;
+}
+
+.preview-button {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0;
+  border: 0;
+  border-radius: inherit;
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.preview-button:hover,
+.preview-button:focus-visible {
+  background: rgba(0, 0, 0, 0.65);
+  outline: 2px solid rgba(255, 255, 255, 0.8);
+  outline-offset: -2px;
+}
+
+.preview-button[data-state='playing'] {
+  background: rgba(15, 118, 110, 0.7);
+}
+
+.preview-spinner {
+  animation: preview-spin 0.9s linear infinite;
+}
+
+@keyframes preview-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .song-title {

--- a/tests/e2e/request.spec.ts
+++ b/tests/e2e/request.spec.ts
@@ -1,5 +1,19 @@
 import { test, expect } from '@playwright/test';
 
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    // Stub HTMLMediaElement.play/pause so Chromium's autoplay policy and the
+    // absence of real audio data do not flake the smoke test.
+    HTMLMediaElement.prototype.play = function () {
+      queueMicrotask(() => this.dispatchEvent(new Event('playing')));
+      return Promise.resolve();
+    };
+    HTMLMediaElement.prototype.pause = function () {
+      this.dispatchEvent(new Event('pause'));
+    };
+  });
+});
+
 test('smoke: user can search and prepare a song request', async ({ page }) => {
   await page.route('**/.netlify/functions/search**', async (route, request) => {
     const url = new URL(request.url());
@@ -56,6 +70,15 @@ test('smoke: user can search and prepare a song request', async ({ page }) => {
   await expect(requestButton).toBeDisabled();
 
   await page.fill('input[aria-label="Your name"]', 'Avery');
+
+  const previewButton = page.getByRole('button', {
+    name: 'Preview Digital Love by Daft Punk'
+  });
+  await expect(previewButton).toHaveAttribute('aria-pressed', 'false');
+  await previewButton.click();
+  await expect(previewButton).toHaveAttribute('aria-pressed', 'true');
+  await previewButton.click();
+  await expect(previewButton).toHaveAttribute('aria-pressed', 'false');
 
   await requestButton.click();
 


### PR DESCRIPTION
## Summary

- Adds a tappable play/pause button overlaid on the album artwork for each search result that has a `previewUrl`, playing the 30-second iTunes AAC preview inline.
- Single shared `<audio>` element enforces the single-player invariant (only one preview plays at a time); starting a new preview auto-stops the previous one.
- Hides the overlay entirely when a track has no `previewUrl`; `preload="none"` so scrolling results doesn't burn mobile data; 44×44 tap target; `aria-label` + `aria-pressed`.
- Extracts a small `PreviewButton` component under `src/components/`.
- `audio.play()` rejection handler silently swallows `AbortError` (rapid toggling) and warns on others.
- Effect pauses + clears state when the playing track drops out of `results` (e.g. new search query).

## Test plan

- [x] `npm run lint` passes
- [x] `npm run test:unit` passes (91 tests, 5 new)
- [x] `npm run build` succeeds
- [ ] `npm run test:e2e` (Playwright, chromium + mobile-chrome) — verify locally before merge
- [ ] Manual: verify preview plays on iOS Safari, noting the ringer-switch caveat documented in `CLAUDE.md`

## Follow-ups (created during review)

- #84 — preview spinner may stall if media events don't fire on slow networks
- #85 — surface preview playback errors with a user-visible indicator

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)