### PR TITLE
fix(ui): guard preview spinner against stalls on slow networks (#84)

### DIFF
--- a/docs/plan/issues/84_preview_spinner_stall_guard.md
+++ b/docs/plan/issues/84_preview_spinner_stall_guard.md
@@ -1,0 +1,199 @@
+# GitHub Issue #84: fix(ui): preview spinner may stall if media events do not fire on slow networks
+
+**Issue:** [#84](https://github.com/denhamparry/djrequests/issues/84)
+**Status:** Planning
+**Date:** 2026-04-16
+
+## Problem Statement
+
+In `src/App.tsx`, `loadingSongId` is cleared only when `playing`, `pause`,
+`ended`, or `error` fires on the shared `<audio>` element. On stalled-network
+edge cases (some mobile Safari, backgrounded tabs), `play()` can resolve
+without any of those events firing promptly — the button stays in its
+loading spinner state indefinitely.
+
+### Current Behavior
+
+- User taps preview on a flaky network.
+- Spinner spins; never advances to `playing` (because media data never
+  buffers) and never errors (because the socket hasn't timed out yet).
+- Button appears broken until the user clicks it again or navigates away.
+
+### Expected Behavior
+
+- If the audio element cannot start playback within a reasonable window,
+  the spinner clears and the button returns to idle.
+- User can try again without refreshing.
+
+## Current State Analysis
+
+### Relevant Code
+
+- **`src/App.tsx`** `ensureAudio()` (lines 28–44) wires listeners for
+  `playing`, `ended`, `pause`, `error`. No listener for `stalled`.
+- **`togglePreview()`** (lines 46–69) sets `loadingSongId = song.id`
+  before `audio.play()`. There is no bounded timeout guarding the
+  transition from loading → playing.
+
+### Related Context
+
+- `HTMLMediaElement` fires `stalled` when the browser is trying to fetch
+  media data but cannot make progress. Firing it does not terminate
+  the load — it is diagnostic. That makes it the right signal for a
+  "user-visible reset" without also forcibly aborting the fetch.
+- A bounded safety timeout (e.g. 8 s) is cheap belt-and-braces and
+  covers the "events never fire at all" worst case.
+
+## Solution Design
+
+### Approach
+
+Apply **both** guards — they handle different failure modes and their
+costs are trivial:
+
+1. **`stalled` event listener** — clears `loadingSongId` when the
+   browser signals lack of progress. The audio element keeps trying; if
+   data eventually arrives, `playing` fires normally.
+2. **Safety timeout** — set when `loadingSongId` flips to a song id;
+   clears `loadingSongId` after a ceiling (8 s). Cleared on `playing`,
+   `pause`, `ended`, `error`, and on unmount. Ref-stored so we can
+   cancel it.
+
+Both guards clear only `loadingSongId`, never `playingSongId` — the
+playing-state invariant is owned by `pause`/`ended`/`error`.
+
+### Trade-offs
+
+- **`stalled` alone**: may not fire in all browsers / failure modes. ❌
+- **Timeout alone**: works but has to fire even in healthy cases if the
+  user's connection is just slow. ❌
+- **Both**: stalled fires fast when available; timeout is a last-resort
+  ceiling. ✅
+
+### Benefits
+
+- Preview button always recovers within ≤ 8 s worst case.
+- No new dependencies; minimal code.
+
+## Implementation Plan
+
+### Step 1: Add `stalled` listener + safety timeout ref
+
+**File:** `src/App.tsx`
+
+**Changes:**
+
+- Add `const loadingTimer = useRef<ReturnType<typeof setTimeout> | null>(null);`.
+- Extract a tiny helper `clearLoadingTimer()` that clears and nulls the
+  ref — used in 4 places.
+- In `ensureAudio`, add:
+  - `audio.addEventListener('stalled', () => setLoadingSongId(null));`
+  - The existing `playing`, `pause`, `ended`, `error` listeners also
+    call `clearLoadingTimer()`.
+- In `togglePreview` at the play-branch (after `setLoadingSongId(song.id)`),
+  clear any existing timer and start a new one:
+
+  ```ts
+  clearLoadingTimer();
+  loadingTimer.current = setTimeout(() => {
+    setLoadingSongId(null);
+    loadingTimer.current = null;
+  }, PREVIEW_LOADING_TIMEOUT_MS);
+  ```
+
+- Add a module-level constant `const PREVIEW_LOADING_TIMEOUT_MS = 8000;`.
+- In the unmount `useEffect` return, call `clearLoadingTimer()` too.
+
+### Step 2: Tests
+
+**File:** `src/__tests__/PreviewButton.test.tsx`
+
+**Changes:**
+
+- Add two new cases:
+  1. **`stalled` event clears the loading state** — click preview, do
+     not dispatch `playing`, dispatch `stalled` instead; assert the
+     button has `data-state="idle"` (loading cleared). Note:
+     `aria-pressed` must remain `true` — playing state still holds
+     until the element itself transitions.
+  2. **Safety timeout clears the loading state after 8 s** — use
+     `vi.useFakeTimers()`; click preview; advance time by 8000 ms; stub
+     `play()` so `playing` never dispatches; assert `data-state="idle"`.
+
+Existing tests remain untouched — the `play` spy auto-dispatches
+`playing`, so the timer never fires and is always cleared by the
+`playing` listener.
+
+### Step 3: Playwright
+
+No Playwright change needed — existing smoke covers the happy path;
+stall behaviour is not worth an E2E-level assertion (timing-sensitive,
+not user-visible on a green connection).
+
+## Testing Strategy
+
+### Unit Testing
+
+Covered by Step 2. 2 new cases; all existing 91 tests must still pass
+without modification.
+
+### Integration Testing
+
+Manual: throttle network to "Slow 3G" in Chrome DevTools, tap a preview,
+observe the spinner clears within 8 s even if no playback starts.
+
+### Regression Testing
+
+- The existing `toggles play and pause on click` test's `play` stub
+  dispatches `playing` via `queueMicrotask`; the `playing` listener
+  will call `clearLoadingTimer` — no change in behaviour.
+- The single-player test rapidly clicks between two tracks; each call
+  resets the timer. Safe.
+
+## Success Criteria
+
+- [ ] `stalled` event listener added
+- [ ] Safety timeout (8 s) added, cleared in all exit paths
+- [ ] 2 new unit tests pass
+- [ ] All existing 91 tests still pass
+- [ ] `npm run lint && npm run test:unit && npm run build` green
+- [ ] pre-commit passes
+
+## Files Modified
+
+1. `src/App.tsx` — `stalled` listener + `loadingTimer` ref + constant
+2. `src/__tests__/PreviewButton.test.tsx` — 2 new cases
+3. `docs/plan/issues/84_preview_spinner_stall_guard.md` — this plan
+
+## Related Issues and Tasks
+
+### Related
+
+- #83 — introduced the preview overlay (merged in #86)
+- #85 — user-visible feedback for playback errors (complementary)
+
+## References
+
+- [GitHub Issue #84](https://github.com/denhamparry/djrequests/issues/84)
+- [MDN: HTMLMediaElement `stalled` event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/stalled_event)
+
+## Notes
+
+### Key Insights
+
+- `stalled` is diagnostic, not terminal — it does not abort the load.
+  Using it to clear the spinner is exactly right: "we don't have data
+  *yet*; stop lying to the user about progress." If data arrives later,
+  `playing` will fire normally.
+- The safety timeout must not reset `playingSongId` — that would
+  desync the UI from actual audio state if the audio *does* eventually
+  start playing. Only the loading indicator is a UI concern.
+
+### Alternative Approaches Considered
+
+1. **Listen for `waiting` instead of `stalled`** — `waiting` fires when
+   playback pauses for buffering *after* playback started. Wrong
+   signal for our "never started" case. ❌
+2. **Abort the load on timeout** — too aggressive; `stalled` can be
+   transient. ❌
+3. **Both `stalled` + 8 s timeout** — chosen. ✅

--- a/docs/plan/issues/84_preview_spinner_stall_guard.md
+++ b/docs/plan/issues/84_preview_spinner_stall_guard.md
@@ -1,7 +1,7 @@
 # GitHub Issue #84: fix(ui): preview spinner may stall if media events do not fire on slow networks
 
 **Issue:** [#84](https://github.com/denhamparry/djrequests/issues/84)
-**Status:** Planning
+**Status:** Reviewed (Approved)
 **Date:** 2026-04-16
 
 ## Problem Statement
@@ -197,3 +197,40 @@ observe the spinner clears within 8 s even if no playback starts.
 2. **Abort the load on timeout** — too aggressive; `stalled` can be
    transient. ❌
 3. **Both `stalled` + 8 s timeout** — chosen. ✅
+
+## Plan Review
+
+**Reviewer:** Claude Code (workflow-research-plan)
+**Review Date:** 2026-04-16
+
+### Review Summary
+
+- **Overall Assessment:** Approved (with one required UX correction)
+- **Confidence Level:** High
+
+### Required Changes
+
+- [ ] On `stalled` or the 8 s timeout firing, call `audio.pause()` and
+      clear BOTH `loadingSongId` and `playingSongId`. Clearing only
+      `loadingSongId` would leave the button showing the pause icon
+      (`aria-pressed="true"`) even though no audio is playing — worse
+      UX than a stuck spinner.
+- [ ] `clearLoadingTimer()` must be called in every path that
+      transitions `loadingSongId` away from a song id — including the
+      toggle-off pause branch of `togglePreview`.
+
+### Optional Improvements
+
+- [ ] Add a test exercising rapid-toggle timer cleanup (click A → click
+      B → click B off) to pin the invariant that only one timer is
+      ever alive.
+
+### Verification Checklist
+
+- [x] Root cause addressed (events don't fire → two independent guards)
+- [x] File paths / line numbers verified
+- [x] Test strategy covers new guards
+- [x] No security implications
+- [x] Performance: trivial
+
+**Status change:** Planning → Reviewed (Approved)

--- a/docs/plan/issues/84_preview_spinner_stall_guard.md
+++ b/docs/plan/issues/84_preview_spinner_stall_guard.md
@@ -1,7 +1,7 @@
 # GitHub Issue #84: fix(ui): preview spinner may stall if media events do not fire on slow networks
 
 **Issue:** [#84](https://github.com/denhamparry/djrequests/issues/84)
-**Status:** Reviewed (Approved)
+**Status:** Complete
 **Date:** 2026-04-16
 
 ## Problem Statement
@@ -210,12 +210,12 @@ observe the spinner clears within 8 s even if no playback starts.
 
 ### Required Changes
 
-- [ ] On `stalled` or the 8 s timeout firing, call `audio.pause()` and
+- [x] On `stalled` or the 8 s timeout firing, call `audio.pause()` and
       clear BOTH `loadingSongId` and `playingSongId`. Clearing only
       `loadingSongId` would leave the button showing the pause icon
       (`aria-pressed="true"`) even though no audio is playing — worse
       UX than a stuck spinner.
-- [ ] `clearLoadingTimer()` must be called in every path that
+- [x] `clearLoadingTimer()` must be called in every path that
       transitions `loadingSongId` away from a song id — including the
       toggle-off pause branch of `togglePreview`.
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import type { Song } from '../shared/types';
 import squirrelsImage from '../squirrels.jpeg';
 
 const SUBMIT_COOLDOWN_MS = 3000;
+const PREVIEW_LOADING_TIMEOUT_MS = 8000;
 
 function App() {
   const { query, setQuery, results, status, message, error } = useSongSearch();
@@ -21,23 +22,44 @@ function App() {
   const [loadingSongId, setLoadingSongId] = useState<string | null>(null);
   const cooldownTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const loadingTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const trimmedName = requesterName.trim();
   const hasName = trimmedName.length > 0;
+
+  const clearLoadingTimer = () => {
+    if (loadingTimer.current) {
+      clearTimeout(loadingTimer.current);
+      loadingTimer.current = null;
+    }
+  };
+
+  const resetPreviewState = () => {
+    clearLoadingTimer();
+    setPlayingSongId(null);
+    setLoadingSongId(null);
+  };
 
   const ensureAudio = (): HTMLAudioElement => {
     if (audioRef.current) return audioRef.current;
     const audio = new Audio();
     audio.preload = 'none';
-    audio.addEventListener('playing', () => setLoadingSongId(null));
-    audio.addEventListener('ended', () => {
-      setPlayingSongId(null);
+    audio.addEventListener('playing', () => {
+      clearLoadingTimer();
       setLoadingSongId(null);
     });
-    audio.addEventListener('pause', () => setLoadingSongId(null));
-    audio.addEventListener('error', () => {
-      setPlayingSongId(null);
+    audio.addEventListener('ended', resetPreviewState);
+    audio.addEventListener('pause', () => {
+      clearLoadingTimer();
       setLoadingSongId(null);
+    });
+    audio.addEventListener('error', resetPreviewState);
+    // `stalled` fires when the browser is trying to fetch media data but
+    // cannot make progress. The load itself is not aborted, so we pause
+    // explicitly to stop the buffering attempt and return the UI to idle.
+    audio.addEventListener('stalled', () => {
+      audio.pause();
+      resetPreviewState();
     });
     audioRef.current = audio;
     return audio;
@@ -49,8 +71,7 @@ function App() {
 
     if (playingSongId === song.id) {
       audio.pause();
-      setPlayingSongId(null);
-      setLoadingSongId(null);
+      resetPreviewState();
       return;
     }
 
@@ -58,10 +79,18 @@ function App() {
     audio.src = song.previewUrl;
     setPlayingSongId(song.id);
     setLoadingSongId(song.id);
-    audio.play().catch((err: unknown) => {
-      if (err instanceof Error && err.name === 'AbortError') return;
+
+    clearLoadingTimer();
+    loadingTimer.current = setTimeout(() => {
+      loadingTimer.current = null;
+      audio.pause();
       setPlayingSongId(null);
       setLoadingSongId(null);
+    }, PREVIEW_LOADING_TIMEOUT_MS);
+
+    audio.play().catch((err: unknown) => {
+      if (err instanceof Error && err.name === 'AbortError') return;
+      resetPreviewState();
       if (err instanceof Error) {
         console.warn('Preview playback failed:', err.message);
       }
@@ -71,6 +100,7 @@ function App() {
   useEffect(
     () => () => {
       if (cooldownTimer.current) clearTimeout(cooldownTimer.current);
+      clearLoadingTimer();
       const audio = audioRef.current;
       if (audio) {
         audio.pause();
@@ -86,8 +116,7 @@ function App() {
     const stillPresent = results.some((song) => song.id === playingSongId);
     if (!stillPresent) {
       audioRef.current?.pause();
-      setPlayingSongId(null);
-      setLoadingSongId(null);
+      resetPreviewState();
     }
   }, [results, playingSongId]);
 

--- a/src/__tests__/PreviewButton.test.tsx
+++ b/src/__tests__/PreviewButton.test.tsx
@@ -130,4 +130,59 @@ describe('Preview button', () => {
 
     expect(requestSpy).not.toHaveBeenCalled();
   });
+
+  it('clears the loading spinner when the audio stalls', async () => {
+    // Stub play so it resolves but does NOT dispatch `playing` — simulates a
+    // network that gets the request off but never delivers media data.
+    playSpy.mockImplementation(function () {
+      return Promise.resolve();
+    });
+
+    const { user } = await renderWithTracks([track()]);
+    const btn = screen.getByRole('button', { name: /Preview Song One by Artist A/i });
+
+    await user.click(btn);
+    await vi.waitFor(() => expect(btn).toHaveAttribute('data-state', 'loading'));
+
+    // Simulate the `stalled` event on the shared audio element. The
+    // component should pause and reset both playing + loading state.
+    const audio = document.querySelector('audio') as HTMLAudioElement | null;
+    // jsdom does not mount the <audio> in the DOM since it's created via
+    // `new Audio()`; we dispatch directly on the instance via the spy-captured
+    // `this` binding. Fall back to finding any media element via a stalled
+    // event dispatched to each HTMLMediaElement the spies have seen.
+    const stallTarget = audio ?? (playSpy.mock.contexts[0] as HTMLMediaElement);
+    stallTarget.dispatchEvent(new Event('stalled'));
+
+    await vi.waitFor(() => expect(btn).toHaveAttribute('aria-pressed', 'false'));
+    expect(btn).toHaveAttribute('data-state', 'idle');
+    expect(pauseSpy).toHaveBeenCalled();
+  });
+
+  it('clears the loading spinner after the safety timeout fires', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    playSpy.mockImplementation(function () {
+      return Promise.resolve();
+    });
+
+    try {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      server.use(http.get(searchEndpoint, () => HttpResponse.json({ tracks: [track()] })));
+      render(<App />);
+      await user.type(screen.getByLabelText(/Search songs/i), 'anything');
+      const btn = await screen.findByRole('button', {
+        name: /Preview Song One by Artist A/i
+      });
+
+      await user.click(btn);
+      await vi.waitFor(() => expect(btn).toHaveAttribute('data-state', 'loading'));
+
+      vi.advanceTimersByTime(8000);
+
+      await vi.waitFor(() => expect(btn).toHaveAttribute('aria-pressed', 'false'));
+      expect(btn).toHaveAttribute('data-state', 'idle');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- Adds a `stalled` event listener on the shared preview `<audio>` element that pauses the audio and resets both `playingSongId` and `loadingSongId`, so the button returns to idle (not stuck showing the pause icon).
- Adds an 8 s safety timeout (`PREVIEW_LOADING_TIMEOUT_MS`) as a belt-and-braces ceiling for the worst case where no media event fires at all; cleared in every path that transitions loading state away from a song.
- Extracts small `resetPreviewState` / `clearLoadingTimer` helpers so every exit path uses the same transition (prevents drift).

## Test plan

- [x] `npm run test:unit` — 93 tests pass (2 new)
- [x] `npm run lint` passes
- [x] `npm run build` succeeds
- [ ] Manual: throttle network to Slow 3G in DevTools, tap preview, observe the spinner clears within ≤ 8 s even if no playback starts

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)