### PR TITLE
feat(request): replace dedication field with Song/Karaoke selector

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,9 +83,10 @@ The app uses Google Form as a submission endpoint to avoid managing a database:
 
 ### Configuration Steps
 
-1. Create Google Form with these fields (short answer type):
-   - Visible: `Requester Name`, `Dedication`, `Contact`
-   - Hidden/prefilled: `Track ID`, `Track Name`, `Artist Name`, `Album Name`, `Artwork URL`, `Preview URL`
+1. Create Google Form with these fields:
+   - Visible (short answer): `Requester Name`, `Contact`
+   - Visible (multiple choice, required): `Request type` — options `Song`, `Karaoke`
+   - Hidden/prefilled (short answer): `Track ID`, `Track Name`, `Artist Name`, `Album Name`, `Artwork URL`, `Preview URL`
 
 2. Get prefilled URL:
    - Form → ⋮ menu → "Get pre-filled link"

--- a/README.md
+++ b/README.md
@@ -41,8 +41,12 @@ Web app that lets guests search for tracks, submit requests through a Google For
 - Create a new Google Form titled “Song Request” (or similar) within your Google Workspace.
 - Add visitor-facing fields:
   - Short answer: `Your Name` (optional)
-  - Short answer: `Dedication / Message` (optional)
+  - Multiple choice: `Request type` (required) — options: `Song`, `Karaoke`
   - Short answer: `Contact Method` (optional)
+
+  When updating an existing form, **edit the `Request type` question in
+  place** (do not delete/recreate). This preserves its `entry.<id>`, which
+  the web app already references in `shared/formFields.ts`.
 - Add metadata questions you’ll prefill from the site (short answer works best):
   - `Track ID`
   - `Track Name`

--- a/apps-script/__tests__/format.test.ts
+++ b/apps-script/__tests__/format.test.ts
@@ -10,7 +10,7 @@ describe('buildDocEntry', () => {
       artistName: 'Daft Punk',
       albumName: 'Discovery',
       requesterName: 'Avery',
-      dedication: 'To the dancefloor crew!',
+      requestType: 'Karaoke',
       contact: 'instagram.com/avery',
       submittedAtIso: '2025-10-02T19:30:00.000Z'
     });
@@ -20,7 +20,7 @@ describe('buildDocEntry', () => {
       { label: 'Artist', value: 'Daft Punk' },
       { label: 'Album', value: 'Discovery' },
       { label: 'Requested by', value: 'Avery' },
-      { label: 'Dedication', value: 'To the dancefloor crew!' },
+      { label: 'Request type', value: 'Karaoke' },
       { label: 'Contact', value: 'instagram.com/avery' },
       { label: 'Requested at', value: '2 Oct 2025, 20:30' }
     ]);
@@ -33,7 +33,7 @@ describe('buildDocEntry', () => {
       artistName: 'Mystery Artist',
       albumName: null,
       requesterName: null,
-      dedication: null,
+      requestType: null,
       contact: null,
       submittedAtIso: 'Invalid Date'
     });
@@ -43,7 +43,7 @@ describe('buildDocEntry', () => {
       { label: 'Artist', value: 'Mystery Artist' },
       { label: 'Album', value: '—' },
       { label: 'Requested by', value: 'Guest' },
-      { label: 'Dedication', value: '—' },
+      { label: 'Request type', value: '—' },
       { label: 'Contact', value: '—' },
       { label: 'Requested at', value: 'Invalid Date' }
     ]);

--- a/apps-script/format.ts
+++ b/apps-script/format.ts
@@ -4,7 +4,7 @@ export type SongRequestSubmission = {
   artistName: string;
   albumName?: string | null;
   requesterName?: string | null;
-  dedication?: string | null;
+  requestType?: string | null;
   contact?: string | null;
   submittedAtIso: string;
 };
@@ -27,7 +27,7 @@ export function buildDocEntry(submission: SongRequestSubmission): DocEntry {
     { label: 'Artist', value: submission.artistName },
     { label: 'Album', value: submission.albumName ?? '—' },
     { label: 'Requested by', value: submission.requesterName ?? 'Guest' },
-    { label: 'Dedication', value: submission.dedication ?? '—' },
+    { label: 'Request type', value: submission.requestType ?? '—' },
     { label: 'Contact', value: submission.contact ?? '—' },
     { label: 'Requested at', value: formattedTimestamp }
   ];

--- a/apps-script/index.ts
+++ b/apps-script/index.ts
@@ -75,7 +75,7 @@ export function onFormSubmit(event: SheetsOnFormSubmitEvent) {
     artistName: namedValues["Artist Name"]?.[0] ?? "Unknown Artist",
     albumName: namedValues["Album Name"]?.[0] ?? null,
     requesterName: namedValues["Requester Name"]?.[0] ?? null,
-    dedication: namedValues["Dedication"]?.[0] ?? null,
+    requestType: namedValues["Request type"]?.[0] ?? null,
     contact: namedValues["Contact"]?.[0] ?? null,
     submittedAtIso: new Date().toISOString(),
   };

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -9,7 +9,7 @@
 - Chosen catalog API: **Apple iTunes Search API** (no auth, free, supports artist/track/album search and 30s preview URLs; rate limit ~20 requests/minute per IP).
 - Backup provider: **Deezer Search** for broader metadata if iTunes coverage proves insufficient; requires API key for production use.
 - Hosting target: **Netlify free tier** with automatic deploys from GitHub branch and environment variable support.
-- Google Form data points: requester name, song title, artist, optional message/dedication, contact method (optional), and hidden fields prefilled with trackId, artworkUrl100, collectionName.
+- Google Form data points: requester name, song title, artist, request type (Song/Karaoke), contact method (optional), and hidden fields prefilled with trackId, artworkUrl100, collectionName.
 - Apps Script workflow: on form submit, append to Google Doc queue with highlighted status placeholder (“Pending”, “Played”) and timestamp; manual moderation remains in Google Doc.
 
 ## Goals & Success Criteria
@@ -46,7 +46,7 @@
   - Capture audio preview support as an enhancement; design results cards with placeholder space for play controls on mobile.
 - **Google Workspace Automation**
   - Configure Google Form within the existing Workspace account with prefilled hidden fields (trackId, trackName, artistName, albumName, artworkUrl, previewUrl).
-  - Connect Form to Sheet capturing requester name, dedication, contact method, and system metadata.
+  - Connect Form to Sheet capturing requester name, request type (Song/Karaoke), contact method, and system metadata.
   - Write Apps Script (executing under the owner’s Workspace account) to sync Sheet entries into a readable Google Doc queue; include timestamp, status fields (“Pending”, “Played”), and optional follow-up column for manual notes.
   - Explore notifications (email or mobile push) for new requests.
 - **Infrastructure & Tooling**

--- a/docs/plan/issues/93_replace_dedication_with_song_karaoke_selector.md
+++ b/docs/plan/issues/93_replace_dedication_with_song_karaoke_selector.md
@@ -1,7 +1,7 @@
 # GitHub Issue #93: Replace "Dedication (optional)" free-text with "Song" / "Karaoke" selection
 
 **Issue:** [#93](https://github.com/denhamparry/djrequests/issues/93)
-**Status:** Reviewed (Approved)
+**Status:** Complete
 **Date:** 2026-04-17
 
 ## Problem Statement
@@ -615,16 +615,16 @@ re-using existing `.input-label` pattern by wrapping radios in a
 **Changes that must be made during implementation (no plan revision
 required):**
 
-- [ ] In Step 3 (`netlify/functions/request.ts`), add an inline comment
+- [x] In Step 3 (`netlify/functions/request.ts`), add an inline comment
       above the `REQUEST_TYPE_LABEL` map noting it must match Google Form
       option labels exactly.
-- [ ] In Step 6 (`tests/e2e/request.spec.ts`), make the new radio
+- [x] In Step 6 (`tests/e2e/request.spec.ts`), make the new radio
       interaction explicit (`getByRole('radio', { name: 'Karaoke'
       }).check()` or `.click()`), not just an outgoing-body assertion.
-- [ ] During Step 4 (`src/App.tsx`), if `.input-label` does not lay out
+- [x] During Step 4 (`src/App.tsx`), if `.input-label` does not lay out
       cleanly on `<fieldset>`, add a scoped `.request-type` CSS rule
       rather than forcing the existing class.
-- [ ] After the `shared/types.ts` rename, run `npx tsc --noEmit` to
+- [x] After the `shared/types.ts` rename, run `npx tsc --noEmit` to
       flush any stray `requester.dedication` references before touching
       test files (cheap compile-time sweep).
 

--- a/docs/plan/issues/93_replace_dedication_with_song_karaoke_selector.md
+++ b/docs/plan/issues/93_replace_dedication_with_song_karaoke_selector.md
@@ -1,0 +1,462 @@
+# GitHub Issue #93: Replace "Dedication (optional)" free-text with "Song" / "Karaoke" selection
+
+**Issue:** [#93](https://github.com/denhamparry/djrequests/issues/93)
+**Status:** Planning
+**Date:** 2026-04-17
+
+## Problem Statement
+
+The request modal currently exposes a free-text `Dedication (optional)` input
+that guests rarely use as intended (a message to the crowd). In practice the
+DJ needs to tell requests apart by **type** — regular track vs. karaoke —
+since karaoke requests are routed differently during events.
+
+### Current Behavior
+
+- Free-text `<input id="dedication">` rendered in `src/App.tsx` (label
+  "Dedication (optional)").
+- Value flows as `requester.dedication` through `submitSongRequest` →
+  `/.netlify/functions/request` → validated as an optional string (up to 500
+  chars) → submitted to Google Form field `entry.1792970976` → surfaced in
+  the DJ's Google Doc queue under the `Dedication` row.
+- Freeform strings produce low-signal queue entries; karaoke vs. song is not
+  recorded at all.
+
+### Expected Behavior
+
+- Request modal shows a required **Song / Karaoke** selector (radio group),
+  defaulting to `Song` for minimal friction.
+- The selected value is sent through the existing Google Form entry ID
+  (`entry.1792970976`), surfaced in the Google Doc queue under a new
+  `Request type` row.
+- Validation accepts only `song` or `karaoke`; anything else is rejected.
+
+## Current State Analysis
+
+### Relevant Code/Config
+
+- `src/App.tsx:20` — `useState('')` for dedication; `src/App.tsx:247-257` —
+  label + input; `src/App.tsx:188, 194-197` — trims and conditionally omits
+  the value when submitting.
+- `shared/types.ts:14-18` — `Requester.dedication?: string`.
+- `shared/formFields.ts:9` — `dedication: "entry.1792970976"`.
+- `netlify/functions/_validate.ts:39-44, 85-86, 101-105` — `optionalString`
+  used for `requester.dedication`; branded `ValidatedRequester.dedication:
+  string | null`.
+- `netlify/functions/request.ts:155` — `appendField(params,
+  FORM_FIELD_IDS.dedication, requester.dedication)`.
+- `apps-script/index.ts:79` — `namedValues["Dedication"]?.[0] ?? null`.
+- `apps-script/format.ts:30` — row label `"Dedication"`.
+- `src/lib/googleForm.ts` — forwards `Requester` unchanged; no dedication
+  logic of its own.
+- `tests/e2e/request.spec.ts` — Playwright smoke test; currently does not
+  interact with the dedication field.
+- `README.md:44` + project `CLAUDE.md` — describe the form field as
+  `Dedication / Message` short answer.
+
+### Related Context
+
+- The Google Form entry ID `entry.1792970976` is stable when the question
+  type is changed in-place (short answer → multiple choice). The **question
+  title** is what Apps Script keys off via `namedValues["Dedication"]` — if
+  the title changes, this lookup must change too. Editing the existing
+  question avoids both a new entry ID and broken form responses.
+- `_validate.ts` uses branded types (`ValidatedRequester`) to separate
+  unvalidated input from validated payloads — the new field must preserve
+  that pattern.
+- No existing plan touches this field. Most recent related work is
+  `docs/plan/issues/51_tighten_requester_name_required.md` (required-name
+  validation) and `docs/plan/issues/49_brand_validated_types.md` (brand
+  pattern).
+
+## Solution Design
+
+### Approach
+
+- Introduce a new domain field `requestType: 'song' | 'karaoke'` on
+  `Requester`, **replacing** `dedication`. This is a small, breaking rename
+  contained to one repo and one Google Form.
+- Rename the `FORM_FIELD_IDS.dedication` key to `FORM_FIELD_IDS.requestType`
+  but **keep the entry ID value `entry.1792970976`** — the Google Form
+  question stays the same underlying field.
+- Default the UI to `Song`; render as a radio group for touch friendliness
+  and accessibility (keyboard + screen reader support out of the box).
+- Enforce the enum in `_validate.ts` by adding an `enumField` helper; the
+  field becomes **required** (no more optional) because we default at the
+  UI.
+- In `apps-script/index.ts`, update the `namedValues["Dedication"]` lookup
+  to `namedValues["Request type"]` so the Apps Script trigger still reads
+  the right column after the form question title change. Capitalise the
+  form value on the way into the Doc (`Song` / `Karaoke`).
+- Rename the Doc row label from `Dedication` to `Request type` in
+  `apps-script/format.ts`.
+
+### Implementation
+
+#### Wire values
+
+The UI submits lowercase tokens (`song` / `karaoke`) to the Netlify function.
+The function passes them to the Google Form unchanged — Google Forms accepts
+the option's label text, so the form options must be **exactly** `Song` and
+`Karaoke` (capitalised). To keep wire/form alignment, the Netlify function
+will map `song → 'Song'` and `karaoke → 'Karaoke'` before setting the form
+param. This keeps the internal type system lowercase-canonical while matching
+the form's display labels.
+
+Alternative considered: submit capitalised tokens from the UI. Rejected to
+avoid mixing presentation and wire format.
+
+#### Google Form change (manual)
+
+Documented in `README.md` and project `CLAUDE.md`:
+
+1. Edit the existing "Dedication / Message" question (do NOT delete/recreate
+   — would invalidate `entry.1792970976`).
+2. Change type from Short answer → Multiple choice.
+3. Set options: `Song`, `Karaoke`.
+4. Rename question title to `Request type`.
+5. Mark required (to match backend).
+
+### Benefits
+
+- DJ immediately sees request type in the queue.
+- Frees the existing Google Form field for re-use (no new entry ID needed).
+- Removes a rarely-useful free-text input that contributed no queue signal.
+
+## Implementation Plan
+
+### Step 1: Shared contract (types + form field rename)
+
+**File:** `shared/types.ts`
+
+**Changes:**
+
+- Replace `dedication?: string` with `requestType: RequestType` on
+  `Requester`.
+- Export `RequestType = 'song' | 'karaoke'` and `REQUEST_TYPES: readonly
+  RequestType[] = ['song', 'karaoke'] as const`.
+
+**File:** `shared/formFields.ts`
+
+**Changes:**
+
+- Rename key `dedication` → `requestType`, keeping value
+  `"entry.1792970976"`.
+
+### Step 2: Validation
+
+**File:** `netlify/functions/_validate.ts`
+
+**Changes:**
+
+- Import `REQUEST_TYPES` / `RequestType` from `shared/types`.
+- Add a generic `enumField<T extends string>(value, field, allowed)`
+  helper that returns the value if it is in `allowed` or an error.
+- Update `ValidatedRequester` to:
+
+  ```ts
+  {
+    name: string;
+    requestType: RequestType;
+    contact: string | null;
+  }
+  ```
+
+  (drop `dedication`; `requestType` is required and non-null).
+
+- In `validateRequestBody`, replace the dedication branch with a required
+  enum check on `requester.requestType`.
+
+**File:** `netlify/functions/__tests__/_validate.test.ts`
+
+**Changes:**
+
+- Replace dedication-related cases with:
+  - accepts `song` and `karaoke`,
+  - rejects missing `requestType` (`requester.requestType is required`),
+  - rejects unknown value (`requester.requestType must be one of song,
+    karaoke` — exact wording to match helper),
+  - rejects non-string value (number / object).
+- Update the "accepts minimal valid payload" case to include
+  `requestType: 'song'`.
+- Update the "accepts full payload" case to include `requestType:
+  'karaoke'` and remove the `dedication` expectation.
+- Update the branded-type compile-time guard to match the new
+  `ValidatedRequester` shape (no `dedication`, has `requestType`).
+
+### Step 3: Request function
+
+**File:** `netlify/functions/request.ts`
+
+**Changes:**
+
+- Replace:
+
+  ```ts
+  appendField(params, FORM_FIELD_IDS.dedication, requester.dedication);
+  ```
+
+  with:
+
+  ```ts
+  const REQUEST_TYPE_LABEL: Record<RequestType, string> = {
+    song: 'Song',
+    karaoke: 'Karaoke'
+  };
+  appendField(
+    params,
+    FORM_FIELD_IDS.requestType,
+    REQUEST_TYPE_LABEL[requester.requestType]
+  );
+  ```
+
+- Import `RequestType` from `shared/types`.
+
+**File:** `netlify/functions/__tests__/request.test.ts`
+
+**Changes:**
+
+- Update any fixture that sends `requester.dedication` to use
+  `requester.requestType: 'song'` (or `'karaoke'` where relevant).
+- Add an assertion that the outgoing URLSearchParams contain
+  `entry.1792970976=Song` (or `Karaoke`).
+
+### Step 4: Frontend (request modal)
+
+**File:** `src/App.tsx`
+
+**Changes:**
+
+- Replace `const [dedication, setDedication] = useState('')` with `const
+  [requestType, setRequestType] = useState<RequestType>('song')`.
+- Replace the `<label htmlFor="dedication">` block with a `<fieldset>` +
+  `<legend>` radio group labelled "Request type" with two radios (`Song`,
+  `Karaoke`). `Song` is checked by default.
+- In `handleRequest`, remove dedication trimming and pass `requestType`
+  through:
+
+  ```ts
+  await submitSongRequest(song, { name: trimmedName, requestType });
+  ```
+
+- Import `RequestType` from `../shared/types`.
+
+**Styling:** Add minimal radio styles if the default layout is ugly; prefer
+re-using existing `.input-label` pattern by wrapping radios in a
+`<fieldset class="input-label">` so styling stays consistent.
+
+### Step 5: Apps Script (Doc formatter + trigger)
+
+**File:** `apps-script/format.ts`
+
+**Changes:**
+
+- In `SongRequestSubmission`, rename the optional `dedication?: string |
+  null` to `requestType?: string | null` (stays optional at this layer
+  because the form response could in theory be empty for old rows).
+- In `buildDocEntry`, replace the `Dedication` metadata row with:
+
+  ```ts
+  { label: 'Request type', value: submission.requestType ?? '—' }
+  ```
+
+**File:** `apps-script/index.ts`
+
+**Changes:**
+
+- Replace:
+
+  ```ts
+  dedication: namedValues["Dedication"]?.[0] ?? null,
+  ```
+
+  with:
+
+  ```ts
+  requestType: namedValues["Request type"]?.[0] ?? null,
+  ```
+
+**File:** `apps-script/__tests__/format.test.ts`
+
+**Changes:**
+
+- Replace `dedication` fields with `requestType` in both test cases.
+- Update expected metadata row label/value accordingly (`Request type` / the
+  selected value, `'—'` for the fallback case).
+
+### Step 6: E2E smoke test
+
+**File:** `tests/e2e/request.spec.ts`
+
+**Changes:**
+
+- Before clicking the request button, assert the default `Song` radio is
+  checked and the `Karaoke` radio is not, then click `Karaoke`.
+- Extend the request-route assertion to check
+  `body.requester.requestType === 'karaoke'`.
+
+### Step 7: Docs
+
+**File:** `README.md`
+
+**Changes:**
+
+- In the Google Form setup section (around line 44), replace `Short answer:
+  Dedication / Message (optional)` with `Multiple choice: Request type
+  (required) — options: Song, Karaoke`.
+- Add a note: "Edit the existing question in-place; do not delete/recreate
+  it, so `entry.1792970976` stays stable."
+
+**File:** `CLAUDE.md` (repo — symlinked or plain, as present)
+
+**Changes:**
+
+- In "Configuration Steps → Visible fields", update the field list to show
+  `Request type (multiple choice: Song / Karaoke)` instead of
+  `Dedication`.
+
+## Testing Strategy
+
+### Unit Testing
+
+- `_validate.test.ts` — enum validation (accept both values, reject
+  missing, reject unknown, reject wrong type).
+- `format.test.ts` — `Request type` row renders correctly for both values
+  and falls back to `—` when missing.
+- `request.test.ts` — outgoing form body contains
+  `entry.1792970976=Song|Karaoke`.
+
+### Integration Testing
+
+**Test Case 1: Song request (default)**
+
+1. Load app, enter name, search, click Request with default selection.
+2. Expected: Google Form receives `Song`; Doc shows `Request type: Song`.
+
+**Test Case 2: Karaoke request**
+
+1. Load app, enter name, select `Karaoke`, search, click Request.
+2. Expected: Google Form receives `Karaoke`; Doc shows
+   `Request type: Karaoke`.
+
+**Test Case 3: Malformed request rejected**
+
+1. POST `{ requester: { name: 'x', requestType: 'shout' } }`.
+2. Expected: 400 with error naming `requester.requestType`.
+
+### Regression Testing
+
+- Existing request flow (name required, cooldown, feedback messaging, rate
+  limiting, preview playback) unaffected.
+- `entry.1792970976` still populated — old Google Form / Sheet rows stay
+  addressable.
+- CORS / rate-limit branches untouched.
+
+## Success Criteria
+
+- [ ] Request modal shows a Song/Karaoke radio group, not a free-text input.
+- [ ] Default selection is `Song`; `Karaoke` can be selected.
+- [ ] Both selections produce a valid submission that reaches the Google
+      Form response sheet with the chosen label.
+- [ ] DJ's Google Doc entry shows `Request type: Song` or `Request type:
+      Karaoke`.
+- [ ] `_validate.ts` rejects missing / unknown / non-string values with a
+      field-qualified error.
+- [ ] Unit tests pass (`npm run test:unit`).
+- [ ] Playwright smoke test passes (`npm run test:e2e`).
+- [ ] `npm run lint` clean.
+- [ ] `README.md` and repo `CLAUDE.md` reflect the new field.
+
+## Files Modified
+
+1. `shared/types.ts` — replace `dedication?: string` with `requestType:
+   RequestType`; export `RequestType` + `REQUEST_TYPES`.
+2. `shared/formFields.ts` — rename key `dedication` → `requestType`, keep
+   entry ID.
+3. `netlify/functions/_validate.ts` — add `enumField` helper; replace
+   dedication validation with required `requestType` enum check; update
+   `ValidatedRequester`.
+4. `netlify/functions/__tests__/_validate.test.ts` — replace dedication
+   cases; add enum cases; update branded-type guard.
+5. `netlify/functions/request.ts` — replace dedication append with mapped
+   `requestType` label; import type.
+6. `netlify/functions/__tests__/request.test.ts` — update fixtures and
+   outgoing-body assertions.
+7. `src/App.tsx` — replace dedication input with radio group; update
+   `handleRequest` payload.
+8. `apps-script/format.ts` — rename `dedication` → `requestType` in
+   `SongRequestSubmission` and metadata row.
+9. `apps-script/index.ts` — change `namedValues["Dedication"]` →
+   `namedValues["Request type"]`, rename field.
+10. `apps-script/__tests__/format.test.ts` — update both cases for the new
+    field name and row label.
+11. `tests/e2e/request.spec.ts` — interact with radios; assert outgoing
+    request body carries `requestType`.
+12. `README.md` — update form-setup field description.
+13. `CLAUDE.md` (repo) — update field list in "Configuration Steps".
+
+## Related Issues and Tasks
+
+### Depends On
+
+- None.
+
+### Blocks
+
+- None.
+
+### Related
+
+- `docs/plan/issues/51_tighten_requester_name_required.md` — prior
+  required-field work on `Requester`.
+- `docs/plan/issues/49_brand_validated_types.md` — established the brand
+  pattern we extend here.
+- `docs/plan/issues/033_refactor_share_song_types_dedupe_derive_form_config.md`
+  — prior shared-types refactor the new `RequestType` export piggybacks on.
+
+### Enables
+
+- Future per-type routing in the queue (e.g. separate karaoke section in
+  the Doc).
+
+## References
+
+- [GitHub Issue #93](https://github.com/denhamparry/djrequests/issues/93)
+- `shared/types.ts`, `shared/formFields.ts`, `netlify/functions/_validate.ts`
+- `apps-script/index.ts`, `apps-script/format.ts`
+
+## Notes
+
+### Key Insights
+
+- **Google Form entry IDs are stable across question-type edits.** Editing
+  the existing question preserves `entry.1792970976` and avoids rewiring
+  `formFields.ts`. Deleting + recreating would force a new ID.
+- **Apps Script `namedValues` keys on the question _title_, not the entry
+  ID.** Changing the title from `Dedication` to `Request type` requires a
+  code change in `apps-script/index.ts` — easy to miss.
+- **Wire vs. display split.** Keeping the internal enum lowercase
+  (`song`/`karaoke`) matches TypeScript conventions; capitalising only at
+  the Form boundary keeps presentation concerns out of the type system.
+
+### Alternative Approaches Considered
+
+1. **Keep the field name `dedication` internally, just swap the UI.** ❌
+   Preserves surface continuity but misleads every reader of the code —
+   the field no longer represents a dedication. Not worth the confusion.
+2. **Make `requestType` optional with a `null` / unknown fallback.** ❌
+   The whole point is to classify every request; defaulting at the UI is
+   simpler and catches form-response drift at the validator.
+3. **Add a new Google Form field and leave dedication in place.** ❌
+   Duplicates queue surface and doesn't address the "dedication rarely
+   used" observation from the issue.
+4. **Chosen: Rename field end-to-end, reuse `entry.1792970976`.** ✅
+   Clean rename, stable form wiring, explicit validation.
+
+### Best Practices
+
+- Run the E2E smoke test after the Apps Script trigger is updated; the
+  `namedValues["Request type"]` key mismatch is silent (writes `—` to the
+  Doc instead of throwing).
+- After merging, manually edit the live Google Form question **in place**
+  before the next event — code alone will not update Google-side state.

--- a/docs/plan/issues/93_replace_dedication_with_song_karaoke_selector.md
+++ b/docs/plan/issues/93_replace_dedication_with_song_karaoke_selector.md
@@ -1,7 +1,7 @@
 # GitHub Issue #93: Replace "Dedication (optional)" free-text with "Song" / "Karaoke" selection
 
 **Issue:** [#93](https://github.com/denhamparry/djrequests/issues/93)
-**Status:** Planning
+**Status:** Reviewed (Approved)
 **Date:** 2026-04-17
 
 ## Problem Statement
@@ -460,3 +460,209 @@ re-using existing `.input-label` pattern by wrapping radios in a
   Doc instead of throwing).
 - After merging, manually edit the live Google Form question **in place**
   before the next event — code alone will not update Google-side state.
+
+## Plan Review
+
+**Reviewer:** Claude Code (workflow-research-plan)
+**Review Date:** 2026-04-17
+**Original Plan Date:** 2026-04-17
+
+### Review Summary
+
+- **Overall Assessment:** Approved
+- **Confidence Level:** High
+- **Recommendation:** Proceed to implementation (with the required changes
+  below folded in during Phase 3; they do not require a plan revision).
+
+### Strengths
+
+- Root cause correctly identified: the plan replaces a low-signal free-text
+  field with a classifier, exactly matching the issue's motivation.
+- Entry-ID stability correctly recognised — the plan reuses
+  `entry.1792970976` by editing the question in-place rather than
+  deleting/recreating it.
+- Apps Script title-vs-ID distinction is explicitly called out in the plan
+  notes (`namedValues` keys on title, not entry ID) — this silent-failure
+  mode is the easiest thing to miss on this change.
+- Wire/presentation split (lowercase canonical + capitalised at the Form
+  boundary) is idiomatic for this codebase and keeps the type system clean.
+- Brand pattern preserved (`ValidatedRequester` updated rather than
+  bypassed) — consistent with `docs/plan/issues/49_brand_validated_types.md`.
+- Implementation steps are specific, file-scoped, and include code snippets
+  where the change is non-trivial.
+
+### Gaps Identified
+
+1. **`tests/e2e/request.spec.ts` preview-stub fixture needs a radio
+   interaction, not just an assertion.**
+   - **Impact:** Low — the test currently doesn't touch the dedication
+     field at all, so "extending" it is new interaction, not an edit.
+   - **Recommendation:** Explicitly state in Step 6 that the test must
+     locate the `Karaoke` radio by role (`getByRole('radio', { name:
+     'Karaoke' })`) and click it before `requestButton.click()`. The
+     current plan wording ("extend the request-route assertion") could be
+     read as assertion-only.
+
+2. **`src/lib/googleForm.ts` type surface.**
+   - **Impact:** Low — this file imports `Requester` from `shared/types`
+     and passes it through untouched, so no code change is needed. But the
+     plan's "Files Modified" list omits it, which is correct, and nothing
+     in the file needs editing. Worth confirming that TypeScript will
+     catch any lingering `dedication` usages at compile time.
+   - **Recommendation:** During implementation, run `npx tsc --noEmit`
+     after the `shared/types.ts` change to flush any other
+     `requester.dedication` references (none expected in non-test code
+     based on grep, but the compile-time guard is free insurance).
+
+3. **README scope.**
+   - **Impact:** Low — the plan lists `README.md` with a single line
+     change, but the README's "Google Form Setup" section has several
+     adjacent lines (43–45) describing the dedication field and the
+     overall form creation flow. The surrounding copy still reads
+     naturally after the one-line edit, so this is fine, but worth a
+     sanity re-read during implementation.
+   - **Recommendation:** When editing, also confirm the "Add
+     visitor-facing fields" bullet list flows correctly with the new
+     wording.
+
+### Edge Cases Not Covered
+
+1. **Form submission with missing `requestType` from a custom client.**
+   - **Current Plan:** Validation rejects with 400 `requester.requestType
+     is required` (covered in Step 2).
+   - **Recommendation:** No change — explicit test case already required
+     in Step 2 ("rejects missing `requestType`"). Covered.
+
+2. **Old Google Sheet rows re-triggered manually.**
+   - **Current Plan:** Not addressed.
+   - **Recommendation:** Non-issue. `onFormSubmit` only fires on new
+     submissions; Apps Script doesn't backfill. Worth a one-line comment
+     in the commit message but no code change needed. (If a developer
+     manually runs `onFormSubmit` against a historical `namedValues`
+     payload during testing, the key lookup will return `—`, which is the
+     intended fallback in `format.ts`.)
+
+3. **Capitalisation mismatch between Form option labels and code.**
+   - **Current Plan:** Netlify function maps `song → Song` / `karaoke →
+     Karaoke` before hitting the Form (Step 3).
+   - **Recommendation:** Add an inline comment in `request.ts` next to the
+     map noting **exact-match requirement** with Form option labels.
+     Silent failure mode: if someone renames the Form option to
+     "Song request" but not the code map, Google Forms will reject the
+     submission with a 400 and the guest sees the 502 from our function
+     with no clue what happened. A defensive integration test isn't
+     worth it, but a comment is.
+
+### Alternatives Reconsidered
+
+1. **`<select>` dropdown instead of radios.**
+   - **Pros:** Saves vertical space; one-click-less code.
+   - **Cons:** Harder to scan at a glance on mobile; radios surface both
+     options simultaneously, which is better for a two-option choice
+     (UX best practice is radios for ≤3 options).
+   - **Verdict:** Plan's choice (radios) is correct.
+
+2. **Keep `dedication` field name internally; only change the UI.**
+   - **Pros:** No type-level churn; formFields.ts key stays the same.
+   - **Cons:** Every future reader has to mentally translate; the field
+     no longer means what it says; tests describe behaviour incorrectly.
+   - **Verdict:** Plan's rename is correct. The short-term churn pays for
+     itself on the first "what does this do?" moment.
+
+3. **Add a new Form field for request type, leave dedication in place.**
+   - **Pros:** Non-breaking; dedication remains available if the DJ ever
+     wants it.
+   - **Cons:** Two fields for what should be one classification; keeps a
+     field the issue explicitly wants removed; queue surface bloats.
+   - **Verdict:** Correctly rejected in the plan's "Alternatives" section.
+
+### Risks and Concerns
+
+1. **`.input-label` CSS reuse on `<fieldset>`.**
+   - **Likelihood:** Medium — the existing class targets a `<label>`
+     wrapping a single `<input>`, and is likely styled with flex/block
+     layout assumptions (e.g. label above input). A `<fieldset>` with
+     `<legend>` + two radios has a different internal structure.
+   - **Impact:** Low — worst case is a visual regression that's easy to
+     spot in dev and fix with a one-line CSS rule.
+   - **Mitigation:** During implementation, visually verify the radio
+     group in the dev server. If `.input-label` doesn't lay out
+     correctly on `<fieldset>`, add a scoped class (e.g. `.request-type`)
+     with minimal radio-group styling (`display: flex; gap: 0.75rem;`
+     for horizontal options) rather than forcing the existing class.
+
+2. **Playwright E2E test timing.**
+   - **Likelihood:** Low — the existing test uses `page.waitForTimeout`
+     for debounced search, not for form interactions.
+   - **Impact:** Low — radios are synchronous.
+   - **Mitigation:** None needed.
+
+3. **Google Form manual step is out-of-band.**
+   - **Likelihood:** High — code lands before the form is edited.
+   - **Impact:** Medium — if the form still has the short-answer
+     `Dedication / Message` question when the new code ships, submissions
+     from the UI will send `Song` to a short-answer field (still stored,
+     but the Doc `Request type` lookup returns `—` because the form
+     question is still titled "Dedication / Message"). The next event
+     queue looks broken until someone runs the manual form edit.
+   - **Mitigation:** The plan's README note is sufficient, but the PR
+     description should reiterate the manual step as a release checklist
+     item. The `Notes → Best Practices` section of the plan already
+     covers this; tighten the wording at PR time.
+
+### Required Changes
+
+**Changes that must be made during implementation (no plan revision
+required):**
+
+- [ ] In Step 3 (`netlify/functions/request.ts`), add an inline comment
+      above the `REQUEST_TYPE_LABEL` map noting it must match Google Form
+      option labels exactly.
+- [ ] In Step 6 (`tests/e2e/request.spec.ts`), make the new radio
+      interaction explicit (`getByRole('radio', { name: 'Karaoke'
+      }).check()` or `.click()`), not just an outgoing-body assertion.
+- [ ] During Step 4 (`src/App.tsx`), if `.input-label` does not lay out
+      cleanly on `<fieldset>`, add a scoped `.request-type` CSS rule
+      rather than forcing the existing class.
+- [ ] After the `shared/types.ts` rename, run `npx tsc --noEmit` to
+      flush any stray `requester.dedication` references before touching
+      test files (cheap compile-time sweep).
+
+### Optional Improvements
+
+- [ ] Add a `// TODO(#93): remove manual form-edit step once infra can
+      manage Forms` comment in `README.md` near the new instruction.
+  (Not blocking; purely documentation hygiene.)
+- [ ] Export the `REQUEST_TYPE_LABEL` map from a shared module so
+      `_validate.ts` and `request.ts` agree on the allowed set via a
+      single source of truth. (Probably over-engineering for two values;
+      mention it in the commit body as a deferred refactor.)
+
+### Verification Checklist
+
+- [x] Solution addresses root cause identified in GitHub issue
+- [x] All acceptance criteria from issue are covered (see mapping below)
+- [x] Implementation steps are specific and actionable
+- [x] File paths and code references are accurate (verified against HEAD)
+- [x] Security implications considered (enum validation rejects untrusted
+      strings; no new injection surface)
+- [x] Performance impact assessed (no change — one more compare in the
+      validator)
+- [x] Test strategy covers critical paths and edge cases
+- [x] Documentation updates planned (README + CLAUDE.md)
+- [x] Related issues/dependencies identified (none blocking)
+- [x] Breaking changes documented (internal rename;
+      `Requester.dedication` removed from wire contract — acceptable, no
+      external API consumers)
+
+**Acceptance-criteria mapping (issue → plan):**
+
+| Issue AC                                           | Plan coverage                                    |
+| -------------------------------------------------- | ------------------------------------------------ |
+| Song/Karaoke selector in modal (not free-text)     | Step 4                                           |
+| Submits successfully, Doc shows chosen value       | Steps 3 + 5                                      |
+| Unit tests for valid values + rejection            | Steps 2 + 5 (`_validate.test.ts`, `format.test`) |
+| Playwright E2E exercises the selector              | Step 6                                           |
+| README and CLAUDE.md reflect new field             | Step 7                                           |
+
+**Status update:** `Under Review` → `Reviewed (Approved)`

--- a/netlify/functions/__tests__/_validate.test.ts
+++ b/netlify/functions/__tests__/_validate.test.ts
@@ -57,10 +57,10 @@ describe('validateRequestBody', () => {
     if (!result.ok) expect(result.error).toMatch(/too long/);
   });
 
-  it('accepts minimal valid payload with requester.name', () => {
+  it('accepts minimal valid payload with requester.name + requestType', () => {
     const result = validateRequestBody({
       song: baseSong,
-      requester: { name: 'Avery' }
+      requester: { name: 'Avery', requestType: 'song' }
     });
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -74,9 +74,20 @@ describe('validateRequestBody', () => {
       });
       expect(result.value.requester).toEqual({
         name: 'Avery',
-        dedication: null,
+        requestType: 'song',
         contact: null
       });
+    }
+  });
+
+  it('accepts requestType: karaoke', () => {
+    const result = validateRequestBody({
+      song: baseSong,
+      requester: { name: 'Avery', requestType: 'karaoke' }
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.requester.requestType).toBe('karaoke');
     }
   });
 
@@ -89,16 +100,45 @@ describe('validateRequestBody', () => {
   it('rejects whitespace-only requester.name', () => {
     const result = validateRequestBody({
       song: baseSong,
-      requester: { name: '   ' }
+      requester: { name: '   ', requestType: 'song' }
     });
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error).toBe('requester.name is required');
   });
 
+  it('rejects missing requester.requestType', () => {
+    const result = validateRequestBody({
+      song: baseSong,
+      requester: { name: 'Avery' }
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe('requester.requestType is required');
+  });
+
+  it('rejects unknown requester.requestType value', () => {
+    const result = validateRequestBody({
+      song: baseSong,
+      requester: { name: 'Avery', requestType: 'shout' }
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe('requester.requestType must be one of song, karaoke');
+    }
+  });
+
+  it('rejects non-string requester.requestType', () => {
+    const result = validateRequestBody({
+      song: baseSong,
+      requester: { name: 'Avery', requestType: 42 }
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe('requester.requestType is required');
+  });
+
   it('trims whitespace on required strings', () => {
     const result = validateRequestBody({
       song: { id: '  1  ', title: ' Song ', artist: ' Artist ' },
-      requester: { name: 'Avery' }
+      requester: { name: 'Avery', requestType: 'song' }
     });
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -125,7 +165,7 @@ describe('validateRequestBody', () => {
       },
       requester: {
         name: 'Avery',
-        dedication: 'For the floor',
+        requestType: 'karaoke',
         contact: '@avery'
       }
     });
@@ -133,6 +173,7 @@ describe('validateRequestBody', () => {
     if (result.ok) {
       expect(result.value.song.album).toBe('Album');
       expect(result.value.requester.name).toBe('Avery');
+      expect(result.value.requester.requestType).toBe('karaoke');
       expect(result.value.requester.contact).toBe('@avery');
     }
   });
@@ -140,12 +181,12 @@ describe('validateRequestBody', () => {
   it('treats empty-string optional fields as null', () => {
     const result = validateRequestBody({
       song: { ...baseSong, album: '' },
-      requester: { name: 'Avery', dedication: '' }
+      requester: { name: 'Avery', requestType: 'song', contact: '' }
     });
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.value.song.album).toBeNull();
-      expect(result.value.requester.dedication).toBeNull();
+      expect(result.value.requester.contact).toBeNull();
     }
   });
 

--- a/netlify/functions/__tests__/request.test.ts
+++ b/netlify/functions/__tests__/request.test.ts
@@ -90,7 +90,7 @@ describe('request function', () => {
           },
           requester: {
             name: 'Avery',
-            dedication: 'For the dance floor',
+            requestType: 'karaoke',
             contact: 'instagram.com/avery'
           }
         })
@@ -113,7 +113,7 @@ describe('request function', () => {
     expect(params.get(FORM_FIELD_IDS.artworkUrl)).toBe('https://example.com/art.jpg');
     expect(params.get(FORM_FIELD_IDS.previewUrl)).toBe('https://example.com/preview.m4a');
     expect(params.get(FORM_FIELD_IDS.requesterName)).toBe('Avery');
-    expect(params.get(FORM_FIELD_IDS.dedication)).toBe('For the dance floor');
+    expect(params.get(FORM_FIELD_IDS.requestType)).toBe('Karaoke');
     expect(params.get(FORM_FIELD_IDS.contact)).toBe('instagram.com/avery');
     expect(params.get('fvv')).toBe('1');
     expect(params.get('submit')).toBe('Submit');
@@ -143,7 +143,7 @@ describe('request function', () => {
       makeEvent({
         body: JSON.stringify({
           song: { id: '1', title: 'T', artist: 'A' },
-          requester: { name: 'Avery' }
+          requester: { name: 'Avery', requestType: 'song' }
         })
       }),
       {} as any
@@ -163,7 +163,7 @@ describe('request function', () => {
       makeEvent({
         body: JSON.stringify({
           song: { id: '1', title: 't', artist: 'a' },
-          requester: { name: 'Avery' }
+          requester: { name: 'Avery', requestType: 'song' }
         })
       }),
       {} as any
@@ -191,7 +191,7 @@ describe('request function', () => {
       makeEvent({
         body: JSON.stringify({
           song: { id: '1', title: 'T', artist: 'A' },
-          requester: { name: 'Avery' }
+          requester: { name: 'Avery', requestType: 'song' }
         })
       }),
       {} as any
@@ -228,7 +228,7 @@ describe('request function', () => {
       makeEvent({
         body: JSON.stringify({
           song: { id: '1', title: 'T', artist: 'A' },
-          requester: { name: 'Avery' }
+          requester: { name: 'Avery', requestType: 'song' }
         })
       }),
       {} as any
@@ -258,7 +258,7 @@ describe('request function', () => {
       makeEvent({
         body: JSON.stringify({
           song: { id: '1', title: 'T', artist: 'A' },
-          requester: { name: 'Avery' }
+          requester: { name: 'Avery', requestType: 'song' }
         })
       }),
       {} as any
@@ -284,7 +284,7 @@ describe('request function', () => {
       makeEvent({
         body: JSON.stringify({
           song: { id: '1', title: 'T', artist: 'A' },
-          requester: { name: 'Avery' }
+          requester: { name: 'Avery', requestType: 'song' }
         })
       }),
       {} as any
@@ -336,8 +336,8 @@ describe('request function', () => {
             song: { id: '99', title: 'T', artist: 'A' },
             requester: {
               name: 'Avery Secret',
-              contact: 'avery@private.test',
-              dedication: 'personal message'
+              requestType: 'song',
+              contact: 'avery@private.test'
             }
           })
         }),
@@ -348,7 +348,6 @@ describe('request function', () => {
       expect(logLine).toContain('trackId=99');
       expect(logLine).not.toMatch(/Avery Secret/);
       expect(logLine).not.toMatch(/avery@private.test/);
-      expect(logLine).not.toMatch(/personal message/);
 
       errorSpy.mockRestore();
     }
@@ -362,7 +361,7 @@ describe('request function', () => {
         makeEvent({
           body: JSON.stringify({
             song: { id: trackId, title: 'T', artist: 'A' },
-            requester: { name: 'Avery' }
+            requester: { name: 'Avery', requestType: 'song' }
           })
         }),
         {} as any
@@ -410,7 +409,7 @@ describe('request function', () => {
       makeEvent({
         body: JSON.stringify({
           song: { id: '1', title: 'Test', artist: 'Artist' },
-          requester: { name: 'Avery' }
+          requester: { name: 'Avery', requestType: 'song' }
         })
       }),
       {} as any
@@ -435,7 +434,7 @@ describe('request function', () => {
       makeEvent({
         body: JSON.stringify({
           song: { id: '1', title: 'T', artist: 'A' },
-          requester: { name: 'Avery' }
+          requester: { name: 'Avery', requestType: 'song' }
         })
       }),
       {} as any
@@ -455,7 +454,7 @@ describe('request function', () => {
     fetchMock.mockResolvedValue({ ok: true, status: 200 });
     const body = JSON.stringify({
       song: { id: '1', title: 'T', artist: 'A' },
-      requester: { name: 'Avery' }
+      requester: { name: 'Avery', requestType: 'song' }
     });
 
     for (let i = 0; i < 5; i += 1) {
@@ -479,7 +478,7 @@ describe('request function', () => {
     fetchMock.mockResolvedValue({ ok: true, status: 200 });
     const body = JSON.stringify({
       song: { id: '1', title: 'T', artist: 'A' },
-      requester: { name: 'Avery' }
+      requester: { name: 'Avery', requestType: 'song' }
     });
 
     for (let i = 0; i < 5; i += 1) {

--- a/netlify/functions/_validate.ts
+++ b/netlify/functions/_validate.ts
@@ -1,4 +1,5 @@
-import type { Song } from '../../shared/types';
+import type { Song, RequestType } from '../../shared/types';
+import { REQUEST_TYPES } from '../../shared/types';
 
 type Brand<T, B extends string> = T & { readonly __brand: B };
 
@@ -7,7 +8,7 @@ export type ValidatedSong = Brand<Song, 'ValidatedSong'>;
 export type ValidatedRequester = Brand<
   {
     name: string;
-    dedication: string | null;
+    requestType: RequestType;
     contact: string | null;
   },
   'ValidatedRequester'
@@ -41,6 +42,22 @@ const optionalString = (value: unknown, field: string): OptionalStringOrError =>
   if (typeof value !== 'string') return { error: `${field} must be a string` };
   if (value.length > MAX_STRING) return { error: `${field} is too long` };
   return value.trim() || null;
+};
+
+type EnumOrError<T extends string> = T | { error: string };
+
+const enumField = <T extends string>(
+  value: unknown,
+  field: string,
+  allowed: readonly T[]
+): EnumOrError<T> => {
+  if (typeof value !== 'string' || !value) {
+    return { error: `${field} is required` };
+  }
+  if (!(allowed as readonly string[]).includes(value)) {
+    return { error: `${field} must be one of ${allowed.join(', ')}` };
+  }
+  return value as T;
 };
 
 const isErrorResult = (value: unknown): value is { error: string } =>
@@ -82,8 +99,12 @@ export const validateRequestBody = (raw: unknown): ValidationResult => {
 
   const name = requireString(requester.name, 'requester.name');
   if (isErrorResult(name)) return { ok: false, error: name.error };
-  const dedication = optionalString(requester.dedication, 'requester.dedication');
-  if (isErrorResult(dedication)) return { ok: false, error: dedication.error };
+  const requestType = enumField(
+    requester.requestType,
+    'requester.requestType',
+    REQUEST_TYPES
+  );
+  if (isErrorResult(requestType)) return { ok: false, error: requestType.error };
   const contact = optionalString(requester.contact, 'requester.contact');
   if (isErrorResult(contact)) return { ok: false, error: contact.error };
 
@@ -100,7 +121,7 @@ export const validateRequestBody = (raw: unknown): ValidationResult => {
       } as ValidatedSong,
       requester: {
         name,
-        dedication,
+        requestType,
         contact
       } as ValidatedRequester
     }

--- a/netlify/functions/request.ts
+++ b/netlify/functions/request.ts
@@ -1,5 +1,6 @@
 import type { Handler } from '@netlify/functions';
 import { FORM_FIELD_IDS } from '../../shared/formFields';
+import type { RequestType } from '../../shared/types';
 import { corsHeaders } from './_cors';
 import { checkRateLimit, resolveClientKey } from './_rateLimit';
 import { validateRequestBody } from './_validate';
@@ -77,6 +78,14 @@ const classifyFetchError = (error: unknown): string => {
   return '[request] Google Form fetch invocation error';
 };
 
+// Display labels sent to the Google Form. MUST match the multiple-choice
+// option text on the Form exactly — Google Forms rejects submissions whose
+// value does not match an existing option, and the user sees a generic 502.
+const REQUEST_TYPE_LABEL: Record<RequestType, string> = {
+  song: 'Song',
+  karaoke: 'Karaoke'
+};
+
 const appendField = (params: URLSearchParams, fieldId: string, value?: string | null) => {
   if (!fieldId) {
     return;
@@ -152,7 +161,11 @@ export const handler: Handler = async (event) => {
   appendField(params, FORM_FIELD_IDS.artworkUrl, song.artworkUrl);
   appendField(params, FORM_FIELD_IDS.previewUrl, song.previewUrl);
   appendField(params, FORM_FIELD_IDS.requesterName, requester.name);
-  appendField(params, FORM_FIELD_IDS.dedication, requester.dedication);
+  appendField(
+    params,
+    FORM_FIELD_IDS.requestType,
+    REQUEST_TYPE_LABEL[requester.requestType]
+  );
   appendField(params, FORM_FIELD_IDS.contact, requester.contact);
   params.set('submit', 'Submit');
 

--- a/shared/formFields.ts
+++ b/shared/formFields.ts
@@ -6,7 +6,7 @@ export const FORM_FIELD_IDS = {
   artworkUrl: "entry.1913993909",
   previewUrl: "entry.729930720",
   requesterName: "entry.924392852",
-  dedication: "entry.1792970976",
+  requestType: "entry.1792970976",
   contact: "entry.40872869",
 } as const;
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -11,8 +11,12 @@ export type Song = {
   previewUrl: string | null;
 };
 
+export type RequestType = 'song' | 'karaoke';
+
+export const REQUEST_TYPES: readonly RequestType[] = ['song', 'karaoke'] as const;
+
 export type Requester = {
   name: string;
-  dedication?: string;
+  requestType: RequestType;
   contact?: string;
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useSongSearch } from './hooks/useSongSearch';
 import { RequestError, submitSongRequest } from './lib/googleForm';
 import PreviewButton, { type PreviewState } from './components/PreviewButton';
-import type { Song } from '../shared/types';
+import type { Song, RequestType } from '../shared/types';
 import squirrelsImage from '../squirrels.jpeg';
 
 const SUBMIT_COOLDOWN_MS = 3000;
@@ -17,7 +17,7 @@ type PlaybackState =
 function App() {
   const { query, setQuery, results, status, message, error } = useSongSearch();
   const [requesterName, setRequesterName] = useState('');
-  const [dedication, setDedication] = useState('');
+  const [requestType, setRequestType] = useState<RequestType>('song');
   const [requestingSongId, setRequestingSongId] = useState<string | null>(null);
   const [cooldownSongId, setCooldownSongId] = useState<string | null>(null);
   const [requestFeedback, setRequestFeedback] = useState<{
@@ -185,15 +185,13 @@ function App() {
       return;
     }
 
-    const trimmedDedication = dedication.trim();
-
     setRequestingSongId(songId);
     setRequestFeedback(null);
 
     try {
       await submitSongRequest(song, {
         name: trimmedName,
-        dedication: trimmedDedication || undefined
+        requestType
       });
       setRequestFeedback({
         type: 'success',
@@ -244,17 +242,29 @@ function App() {
         />
       </label>
 
-      <label className="input-label" htmlFor="dedication">
-        <span className="label-text">Dedication (optional)</span>
-        <input
-          id="dedication"
-          aria-label="Dedication"
-          placeholder="e.g. For Sam's birthday"
-          value={dedication}
-          autoComplete="off"
-          onChange={(event) => setDedication(event.target.value)}
-        />
-      </label>
+      <fieldset className="input-label request-type">
+        <legend className="label-text">Request type</legend>
+        <label className="radio-option">
+          <input
+            type="radio"
+            name="request-type"
+            value="song"
+            checked={requestType === 'song'}
+            onChange={() => setRequestType('song')}
+          />
+          <span>Song</span>
+        </label>
+        <label className="radio-option">
+          <input
+            type="radio"
+            name="request-type"
+            value="karaoke"
+            checked={requestType === 'karaoke'}
+            onChange={() => setRequestType('karaoke')}
+          />
+          <span>Karaoke</span>
+        </label>
+      </fieldset>
 
       <label className="input-label" htmlFor="song-search">
         <span className="label-text">Search songs</span>

--- a/src/styles.css
+++ b/src/styles.css
@@ -47,10 +47,45 @@ h1 {
   margin-bottom: 1rem;
 }
 
+fieldset.input-label {
+  border: none;
+  padding: 0;
+  margin-inline: 0;
+  margin-bottom: 1rem;
+}
+
 .label-text {
   display: block;
   font-weight: 600;
   margin-bottom: 0.5rem;
+}
+
+.request-type {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+}
+
+.request-type .label-text {
+  flex-basis: 100%;
+  padding: 0;
+}
+
+.radio-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.radio-option input[type='radio'] {
+  width: auto;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  backdrop-filter: none;
+  accent-color: #6c5ce7;
 }
 
 input {

--- a/tests/e2e/request.spec.ts
+++ b/tests/e2e/request.spec.ts
@@ -49,6 +49,7 @@ test('smoke: user can search and prepare a song request', async ({ page }) => {
     expect(body.song.id).toBe('321');
     expect(body.song.title).toBe('Digital Love');
     expect(body.requester.name).toBe('Avery');
+    expect(body.requester.requestType).toBe('karaoke');
 
     return route.fulfill({
       status: 200,
@@ -70,6 +71,13 @@ test('smoke: user can search and prepare a song request', async ({ page }) => {
   await expect(requestButton).toBeDisabled();
 
   await page.fill('input[aria-label="Your name"]', 'Avery');
+
+  const songRadio = page.getByRole('radio', { name: 'Song' });
+  const karaokeRadio = page.getByRole('radio', { name: 'Karaoke' });
+  await expect(songRadio).toBeChecked();
+  await expect(karaokeRadio).not.toBeChecked();
+  await karaokeRadio.check();
+  await expect(karaokeRadio).toBeChecked();
 
   const previewButton = page.getByRole('button', {
     name: 'Preview Digital Love by Daft Punk'


### PR DESCRIPTION
## Summary

- Replace the free-text `Dedication (optional)` input with a required **Song / Karaoke** radio group (defaults to `Song`) so the DJ can tell request types apart at a glance.
- End-to-end rename: `Requester.dedication` → `Requester.requestType: 'song' | 'karaoke'`. `FORM_FIELD_IDS.dedication` → `requestType`, **reusing `entry.1792970976`** so the Google Form question can be edited in place instead of recreated.
- Validation hardened: new `enumField` helper in `_validate.ts` rejects missing / unknown / non-string values; field is now **required** on the wire (UI supplies a default).
- Apps Script reads `namedValues[\"Request type\"]` (new title) and surfaces `Request type: Song|Karaoke` in the Doc queue.

Closes #93.

## Manual follow-up (out of band — required before next event)

Edit the live Google Form question **in place**:

1. Change the existing `Dedication / Message` question type from **Short answer** → **Multiple choice**.
2. Set options: `Song`, `Karaoke` (exact capitalisation — the Netlify function maps to these labels).
3. Rename the question title to `Request type`.
4. Mark required.

Do **not** delete and recreate — that rotates \`entry.1792970976\` and breaks the wiring.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test:unit` — 104 tests pass (added 3 enum cases + 1 minimal-valid-payload update)
- [x] `npm run build` — clean
- [x] `pre-commit run` on changed files — pass
- [ ] `npm run test:e2e` — Playwright smoke extended to click `Karaoke` and assert `requester.requestType === 'karaoke'` (please confirm in CI or locally)
- [ ] After merge + manual Google Form edit, submit one of each type from a staging browser and confirm the Google Doc shows `Request type: Song` / `Request type: Karaoke`.

## Follow-up

Enhancement issue opened: #100 (colocate \`REQUEST_TYPE_LABEL\` with \`REQUEST_TYPES\` in \`shared/types\` for a single source of truth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)