### PR TITLE
chore: ignore *.tsbuildinfo in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist/
 coverage/
 test-results/
 playwright-report/
+*.tsbuildinfo
 
 # Local tooling artifacts
 *.log

--- a/docs/plan/issues/106_chore_ignore_tsbuildinfo.md
+++ b/docs/plan/issues/106_chore_ignore_tsbuildinfo.md
@@ -1,0 +1,39 @@
+# GitHub Issue #106: chore: ignore *.tsbuildinfo in .gitignore
+
+**Issue:** [#106](https://github.com/denhamparry/djrequests/issues/106)
+**Status:** Reviewed (Approved)
+**Date:** 2026-04-17
+
+## Problem
+
+`tsconfig.node.tsbuildinfo` appears as untracked in the repo. It's TypeScript's
+incremental build cache, emitted because `tsconfig.node.json` sets
+`composite: true`. The file is machine-specific and regenerates on every
+`tsc` / `vite build`, so it has no value in version control — it only creates
+noise in `git status` and diffs.
+
+## Proposed Change
+
+Add `*.tsbuildinfo` to `.gitignore` (glob, not exact path) so both the current
+`tsconfig.node.tsbuildinfo` and any future variants (e.g.
+`tsconfig.app.tsbuildinfo`, `tsconfig.base.tsbuildinfo`) are ignored.
+
+Place it in the "Node dependencies and build outputs" section alongside
+`dist/` and `coverage/` — it is a build artefact.
+
+## Files Modified
+
+- `.gitignore` — add `*.tsbuildinfo` line
+
+## Verification
+
+1. `.gitignore` contains `*.tsbuildinfo` in the build-outputs section.
+2. `git ls-files | rg tsbuildinfo` returns no matches (nothing currently
+   tracked that the new rule would need to untrack). Confirmed 2026-04-17.
+3. After `npm run build` in a clean checkout, `git status` shows no
+   `*.tsbuildinfo` files as untracked.
+
+## Risks
+
+Low. Single-line `.gitignore` addition. No runtime, build, or test behaviour
+changes.


### PR DESCRIPTION
## Summary

- Add `*.tsbuildinfo` glob to `.gitignore` in the build-outputs section
- Stops TypeScript's incremental build cache (emitted because `tsconfig.node.json` has `composite: true`) from appearing as untracked
- Glob covers the current `tsconfig.node.tsbuildinfo` and any future siblings (e.g. `tsconfig.app.tsbuildinfo`)

## Test plan

- [x] Pre-commit hooks pass (trimmed list, not full suite which has pre-existing markdown debt unrelated to this PR)
- [x] `.gitignore` includes `*.tsbuildinfo`
- [x] No previously tracked `*.tsbuildinfo` files (`git ls-files | rg tsbuildinfo` empty)
- [ ] After `npm run build` in a clean checkout, `git status` shows no `*.tsbuildinfo` files

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)