### PR TITLE
fix(search): redact raw upstream error detail from client response

### DIFF
--- a/docs/plan/issues/108_redact_search_upstream_error_details.md
+++ b/docs/plan/issues/108_redact_search_upstream_error_details.md
@@ -1,7 +1,7 @@
 # GitHub Issue #108: fix(search) — don't return raw upstream error details to the client
 
 **Issue:** [#108](https://github.com/denhamparry/djrequests/issues/108)
-**Status:** Planning
+**Status:** Reviewed (Approved)
 **Branch:** denhamparry.co.uk/fix/gh-issue-108
 **Date:** 2026-04-17
 
@@ -126,3 +126,101 @@ add an optional `requestId?: string` field.
 - Changes to the throttled-branch message — already friendly; adding a
   requestId there is optional polish, not required for acceptance.
 - Logging infrastructure changes (structured logging, log aggregation, etc.).
+
+## Plan Review
+
+**Reviewer:** Claude Code (workflow-research-plan)
+**Review Date:** 2026-04-17
+**Original Plan Date:** 2026-04-17
+
+### Review Summary
+
+- **Overall Assessment:** Approved
+- **Confidence Level:** High
+- **Recommendation:** Proceed to implementation
+
+### Strengths
+
+- Mirrors the established pattern from #50 (already shipped for `request.ts`),
+  so reviewers and operators have a familiar shape (`requestId`, `[search]`
+  log prefix, generic friendly message + machine-readable `code`).
+- Explicitly preserves the frontend contract: `useSongSearch.ts:60–63` keys
+  off `code: 'upstream_unavailable'`, so the user-visible message is
+  unchanged. No frontend changes required.
+- Test plan covers both leak vectors: upstream HTTP status (existing test
+  retro-fitted) and raw network error (new test). Spying on `console.error`
+  with `mockImplementation` keeps test output clean and verifies the log
+  side-effect.
+- Scope is correctly tight — `request.ts:190` and the throttled branch are
+  called out as out-of-scope rather than silently expanded.
+
+### Verified Code References
+
+- `netlify/functions/search.ts:60-62` — raw `error.message` interpolated into
+  `lastDetail`. ✅
+- `netlify/functions/search.ts:79` — raw HTTP status interpolated into
+  `lastDetail`. ✅
+- `netlify/functions/search.ts:123-129` — `kind: 'failed'` returns
+  `outcome.detail`. ✅
+- `netlify/functions/__tests__/search.test.ts:227-246` — existing
+  retries-exhausted test asserts `payload.error` matches `/404/`; will need
+  the assertion update described in Task 4. ✅
+- `netlify/functions/request.ts:8` — `generateRequestId` helper to mirror. ✅
+- `src/hooks/useSongSearch.ts:60-63` — friendly-message branch keys off
+  `code === 'upstream_unavailable'`, so generic backend error string is not
+  shown to users. ✅
+
+### Gaps Identified
+
+None blocking. Two minor observations:
+
+1. **Throttled branch left without a requestId.** Acknowledged as out of
+   scope. Operators triaging a "search throttled" report won't have a log
+   correlation ID. Acceptable — throttling is self-limiting and the friendly
+   message is unambiguous.
+   - **Impact:** Low
+   - **Recommendation:** Leave as-is; revisit only if support load suggests
+     correlation is needed.
+
+### Edge Cases Not Covered
+
+None of concern. The plan covers both leak vectors. The
+`requestId` itself is non-sensitive (random 8-char hex slice of a UUID) and
+poses no information-disclosure risk.
+
+### Risks and Concerns
+
+- **Risk:** Test for `console.error` could pass spuriously if Vitest is
+  configured to swallow console output. Plan mitigates by using
+  `vi.spyOn(console, 'error').mockImplementation(() => {})` and asserting
+  call args directly. ✅
+- **Risk:** Bundle size impact — `crypto.randomUUID` is already used in
+  `request.ts`, so no new global dependency. ✅
+
+### Required Changes
+
+None.
+
+### Optional Improvements
+
+- **Naming polish:** Consider hoisting `generateRequestId` into a tiny
+  shared util (`netlify/functions/_requestId.ts`) since both `search.ts` and
+  `request.ts` now use the identical helper. Not required — duplication of
+  one line is fine, and the existing CLAUDE.md guidance discourages
+  premature abstraction.
+
+### Verification Checklist
+
+- [x] Solution addresses root cause (raw upstream detail in client response)
+- [x] All acceptance criteria from issue #108 are covered
+- [x] Implementation steps are specific and actionable
+- [x] File paths and code references are accurate (verified above)
+- [x] Security implications considered (requestId disclosure is benign)
+- [x] Performance impact assessed (generating one UUID per failed call —
+      negligible)
+- [x] Test strategy covers both leak vectors and the log side-effect
+- [x] No documentation changes required (CLAUDE.md already documents the
+      pattern via #50)
+- [x] Frontend contract preserved (`code: 'upstream_unavailable'` still
+      drives UX)
+- [x] No breaking changes

--- a/docs/plan/issues/108_redact_search_upstream_error_details.md
+++ b/docs/plan/issues/108_redact_search_upstream_error_details.md
@@ -1,0 +1,128 @@
+# GitHub Issue #108: fix(search) — don't return raw upstream error details to the client
+
+**Issue:** [#108](https://github.com/denhamparry/djrequests/issues/108)
+**Status:** Planning
+**Branch:** denhamparry.co.uk/fix/gh-issue-108
+**Date:** 2026-04-17
+
+## Context
+
+In `netlify/functions/search.ts`, the `kind: 'failed'` branch (line 123–129)
+returns `outcome.detail` directly to the client. `outcome.detail` is built up
+inside `fetchFromItunes()` and can contain:
+
+- Raw Node `fetch()` error messages: `network error: ${error.message}`
+  (search.ts:60–62) — could leak internal hostnames, DNS resolution detail,
+  TLS errors, proxy detail, etc.
+- Raw iTunes HTTP status codes: `iTunes Search API returned status ${status}`
+  (search.ts:79).
+
+This is the same class of issue as #50 (already fixed for `request.ts`):
+internal failure detail belongs in `console.error`, not in the response body.
+The frontend in `src/hooks/useSongSearch.ts:60–63` already keys off the
+`code: 'upstream_unavailable'` field for friendly UX, so removing the raw
+detail does not affect the user experience.
+
+The companion `request.ts` function already follows the right pattern:
+generate a `requestId`, log with a sanitised context string, return a generic
+friendly message + `requestId` to the client. We mirror that pattern here.
+
+Surfaced by Shoulder.dev scan and audit (see issue body).
+
+## Approach
+
+In `search.ts`:
+
+1. Generate a short request ID (mirror `request.ts:8` —
+   `crypto.randomUUID().slice(0, 8)`).
+2. In the `kind: 'failed'` branch:
+   - `console.error` the raw `outcome.detail` with a stable prefix and the
+     request ID, so the entry is greppable in Netlify logs.
+   - Return a generic friendly message + `code: 'upstream_unavailable'` +
+     `requestId`.
+3. The `kind: 'throttled'` branch already returns a friendly message — no
+   change beyond also adding a `requestId` for consistency (low value but
+   cheap and aids correlation).
+4. Keep `outcome.detail` typed as before; only the client surface changes.
+
+The `requestId` is included in the response so a user reporting "search is
+broken" can quote it and an operator can grep logs.
+
+## Files Modified
+
+- `netlify/functions/search.ts` — generate requestId, log raw `outcome.detail`
+  via `console.error`, replace client-facing detail with generic string.
+- `netlify/functions/__tests__/search.test.ts` — update the existing
+  "exhausted retries" test (line 240–246) which currently asserts
+  `payload.error` matches `/404/`; new assertions cover (a) absence of raw
+  status / fetch detail in the body, (b) `console.error` called with the raw
+  detail, (c) `requestId` present in the body and matches log entry.
+
+## Implementation
+
+```ts
+// near the top of search.ts (after imports)
+const generateRequestId = (): string => crypto.randomUUID().slice(0, 8);
+
+// in the handler, replace the kind: 'failed' branch:
+if (outcome.kind === 'failed') {
+  const requestId = generateRequestId();
+  console.error(
+    `[search] iTunes upstream failure (requestId=${requestId}): ${outcome.detail}`
+  );
+  return jsonResponse(503, {
+    tracks: [],
+    error: 'Search is temporarily unavailable. Please try again shortly.',
+    code: 'upstream_unavailable',
+    requestId
+  });
+}
+```
+
+The `SearchResponse` type already has an optional `error` and `code` field;
+add an optional `requestId?: string` field.
+
+## Tasks
+
+1. Update `SearchResponse` type in `search.ts` to include `requestId?: string`.
+2. Add `generateRequestId` helper in `search.ts` (mirror `request.ts:8`).
+3. Update the `kind: 'failed'` branch to log + return generic message +
+   requestId.
+4. Update existing test "returns 503 with upstream_unavailable code after
+   retries are exhausted" (`search.test.ts:227`):
+   - Spy on `console.error` (use `vi.spyOn(console, 'error').mockImplementation(() => {})`
+     in beforeEach + restore in afterEach).
+   - Replace `expect(payload.error).toMatch(/404/)` with assertions that the
+     body's `error` is the generic friendly string and does **not** contain
+     "404" or "iTunes Search API returned status".
+   - Assert `payload.code === 'upstream_unavailable'`.
+   - Assert `typeof payload.requestId === 'string'` and length is 8.
+   - Assert `console.error` was called with a string containing the raw
+     "404" detail and the same requestId.
+5. Add a second test covering the network-error exhaustion path: three
+   mocked `fetchMock.mockRejectedValue(new Error('socket hang up'))` in a
+   row, then assert the body does **not** contain "socket hang up" but
+   `console.error` was called with it.
+6. Run `npm run test:unit`, `npm run lint`, pre-commit.
+7. Commit + open PR.
+
+## Acceptance Criteria
+
+- The `kind: 'failed'` response body in `search.ts` contains only a generic
+  friendly string + `code: 'upstream_unavailable'` + `requestId`. No raw
+  status code, no raw fetch error message.
+- `console.error` is called with the raw `outcome.detail` and the same
+  `requestId` that the client receives.
+- Existing tests in `search.test.ts` continue to pass after the assertion
+  update for the retries-exhausted case.
+- New tests cover both upstream-status and network-error redaction.
+- `useSongSearch.ts` UX is unchanged (the `code === 'upstream_unavailable'`
+  branch was already wired in `useSongSearch.ts:60–63`).
+
+## Out of Scope
+
+- Changes to `request.ts:190` (`Google Form responded with status …`) — minor
+  status leak, low value to attackers, separate concern.
+- Changes to the throttled-branch message — already friendly; adding a
+  requestId there is optional polish, not required for acceptance.
+- Logging infrastructure changes (structured logging, log aggregation, etc.).

--- a/docs/plan/issues/108_redact_search_upstream_error_details.md
+++ b/docs/plan/issues/108_redact_search_upstream_error_details.md
@@ -1,7 +1,7 @@
 # GitHub Issue #108: fix(search) — don't return raw upstream error details to the client
 
 **Issue:** [#108](https://github.com/denhamparry/djrequests/issues/108)
-**Status:** Reviewed (Approved)
+**Status:** Complete
 **Branch:** denhamparry.co.uk/fix/gh-issue-108
 **Date:** 2026-04-17
 

--- a/netlify/functions/__tests__/search.test.ts
+++ b/netlify/functions/__tests__/search.test.ts
@@ -224,7 +224,8 @@ describe('search function', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it('returns 503 with upstream_unavailable code after retries are exhausted', async () => {
+  it('returns 503 with upstream_unavailable code after retries are exhausted, redacting upstream detail from the body', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     fetchMock
       .mockResolvedValueOnce(failureResponse(404))
       .mockResolvedValueOnce(failureResponse(404))
@@ -241,7 +242,61 @@ describe('search function', () => {
     expect(fetchMock).toHaveBeenCalledTimes(3);
     const payload = JSON.parse(response.body);
     expect(payload.code).toBe('upstream_unavailable');
-    expect(payload.error).toMatch(/404/);
     expect(payload.tracks).toEqual([]);
+
+    // Body must not leak raw upstream detail.
+    expect(payload.error).toBe(
+      'Search is temporarily unavailable. Please try again shortly.'
+    );
+    expect(payload.error).not.toMatch(/404/);
+    expect(payload.error).not.toMatch(/iTunes Search API returned status/);
+
+    // Body carries a requestId so support can correlate with logs.
+    expect(typeof payload.requestId).toBe('string');
+    expect(payload.requestId).toHaveLength(8);
+
+    // Raw detail is logged server-side with the same requestId.
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const logged = String(errorSpy.mock.calls[0][0]);
+    expect(logged).toContain('[search]');
+    expect(logged).toContain(`requestId=${payload.requestId}`);
+    expect(logged).toContain('iTunes Search API returned status 404');
+
+    errorSpy.mockRestore();
+  });
+
+  it('redacts raw network error detail from the body when network failures exhaust retries', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    fetchMock
+      .mockRejectedValueOnce(new Error('socket hang up'))
+      .mockRejectedValueOnce(new Error('socket hang up'))
+      .mockRejectedValueOnce(new Error('socket hang up'));
+
+    const promise = handler(
+      { queryStringParameters: { term: 'beatles' } } as any,
+      {} as any
+    );
+    await vi.runAllTimersAsync();
+    const response = await promise;
+
+    expect(response.statusCode).toBe(503);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const payload = JSON.parse(response.body);
+    expect(payload.code).toBe('upstream_unavailable');
+
+    // Body must not leak the raw fetch error message.
+    expect(payload.error).toBe(
+      'Search is temporarily unavailable. Please try again shortly.'
+    );
+    expect(payload.error).not.toContain('socket hang up');
+    expect(payload.error).not.toContain('network error');
+
+    // Raw detail is logged server-side.
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const logged = String(errorSpy.mock.calls[0][0]);
+    expect(logged).toContain('socket hang up');
+    expect(logged).toContain(`requestId=${payload.requestId}`);
+
+    errorSpy.mockRestore();
   });
 });

--- a/netlify/functions/search.ts
+++ b/netlify/functions/search.ts
@@ -16,10 +16,13 @@ type SearchResponse = {
   message?: string;
   error?: string;
   code?: 'upstream_unavailable';
+  requestId?: string;
 };
 
 const USER_AGENT = 'djrequests/1.0 (+https://github.com/denhamparry/djrequests)';
 const ITUNES_SEARCH_ENDPOINT = 'https://itunes.apple.com/search';
+
+const generateRequestId = (): string => crypto.randomUUID().slice(0, 8);
 
 // iTunes Search API has a documented intermittent failure mode where it
 // returns HTTP 404 with a `[newNullResponse]` HTML body instead of a real
@@ -121,10 +124,15 @@ export const handler: Handler = async (event) => {
   }
 
   if (outcome.kind === 'failed') {
+    const requestId = generateRequestId();
+    console.error(
+      `[search] iTunes upstream failure (requestId=${requestId}): ${outcome.detail}`
+    );
     return jsonResponse(503, {
       tracks: [],
-      error: outcome.detail,
-      code: 'upstream_unavailable'
+      error: 'Search is temporarily unavailable. Please try again shortly.',
+      code: 'upstream_unavailable',
+      requestId
     });
   }
 


### PR DESCRIPTION
## Summary

- The `kind: 'failed'` branch in `netlify/functions/search.ts` returned `outcome.detail` directly to the client, leaking raw `fetch()` error messages (which can contain internal hostnames, DNS detail, TLS errors) and raw iTunes HTTP status codes.
- This PR mirrors the pattern already used in `request.ts` (after #50): generate a short `requestId`, `console.error` the raw detail with a `[search]` prefix and the request ID, and return a generic friendly message + `code: 'upstream_unavailable'` + `requestId` to the client.
- The frontend (`useSongSearch.ts:60-63`) already keys off the `code` field, so user-visible UX is unchanged.

## Test plan

- [x] `npm run test:unit` — 108/108 pass; 12/12 in `netlify/functions/__tests__/search.test.ts`
- [x] Updated existing retries-exhausted test asserts the body no longer leaks status codes and that `console.error` is called with the raw detail and matching `requestId`
- [x] New test covers the network-error exhaustion path (rejected fetches with `socket hang up`) and asserts the raw error message stays out of the body
- [x] `npm run lint` — clean
- [x] Pre-commit hooks pass

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)