### PR TITLE
feat(ci): auto-assign opened PRs to denhamparry

### DIFF
--- a/.github/workflows/auto-assign-prs.yml
+++ b/.github/workflows/auto-assign-prs.yml
@@ -1,0 +1,25 @@
+name: Auto-assign PRs
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  assign:
+    name: Assign PR to denhamparry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add assignee
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          curl --silent --show-error --fail -X POST \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/assignees" \
+            -d '{"assignees":["denhamparry"]}'


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow (`.github/workflows/auto-assign-prs.yml`) that automatically assigns every newly opened PR — including PRs from dependabot and other bots — to @denhamparry, so all open PRs are trackable from the assignee view. The job calls the GitHub REST API assignees endpoint directly with the built-in `GITHUB_TOKEN`.

## Security note

The workflow uses the `pull_request_target` trigger so it runs with write permissions even for fork and bot PRs. This is safe here because the job **never checks out or executes PR code** — it only makes a single API call using trusted workflow content from the base branch.

## Known limitation

PRs created by other workflows using the default `GITHUB_TOKEN` will **not** trigger this workflow — GitHub intentionally suppresses workflow runs from events created with `GITHUB_TOKEN` to prevent recursion. PRs opened by users, dependabot, or apps/PATs will trigger it normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)