### PR TITLE
feat(ci): request denhamparry review on bot-authored PRs

### DIFF
--- a/.github/workflows/auto-assign-prs.yml
+++ b/.github/workflows/auto-assign-prs.yml
@@ -23,3 +23,14 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/assignees" \
             -d '{"assignees":["denhamparry"]}'
+      - name: Request review
+        if: github.event.pull_request.user.login != 'denhamparry'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          curl --silent --show-error --fail -X POST \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/requested_reviewers" \
+            -d '{"reviewers":["denhamparry"]}'


### PR DESCRIPTION
## Summary

Follow-up to the merged auto-assign PR. Adds a "Request review" step to the auto-assign workflow that requests a review from denhamparry on bot-authored PRs (dependabot, other bots, collaborators). Self-authored PRs are skipped because GitHub forbids requesting a review from the PR author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)